### PR TITLE
route by X-State-ID header to skip body parsing

### DIFF
--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -90,7 +90,7 @@ public class RequestHandler extends Handler.Abstract {
     private static final String BEARER_AUTHORIZATION = "Bearer";
     static final String HEADER_X_API_KEY = "X-API-Key";
     static final String HEADER_X_RATE_LIMIT_REMAINING = "X-RateLimit-Remaining";
-    static final String HEADER_X_STATE_ID = "X-State-Id";
+    static final String HEADER_X_STATE_ID = "X-State-ID";
 
     private final HttpClient httpClient;
     private volatile ShardRouter shardRouter;

--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -2,7 +2,6 @@ package org.unicitylabs.proxy;
 
 import org.unicitylabs.proxy.model.ObjectMapperUtils;
 import org.unicitylabs.proxy.shard.ShardRouter;
-import org.unicitylabs.proxy.shard.ShardingMode;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -34,6 +33,8 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.unicitylabs.proxy.util.CorsUtils;
@@ -89,6 +90,7 @@ public class RequestHandler extends Handler.Abstract {
     private static final String BEARER_AUTHORIZATION = "Bearer";
     static final String HEADER_X_API_KEY = "X-API-Key";
     static final String HEADER_X_RATE_LIMIT_REMAINING = "X-RateLimit-Remaining";
+    static final String HEADER_X_STATE_ID = "X-State-Id";
 
     private final HttpClient httpClient;
     private volatile ShardRouter shardRouter;
@@ -163,9 +165,9 @@ public class RequestHandler extends Handler.Abstract {
             requestBody = null;
         }
 
-        JsonNode root = attemptParsingRequestBodyAsJson(method, requestBody);
+        String jsonRpcMethod = extractJsonRpcMethodFromBody(method, requestBody);
 
-        if (requiresAuthentication(request.getMethod(), root)) {
+        if (requiresAuthentication(request.getMethod(), jsonRpcMethod)) {
             if (!performAuthenticationAndRateLimiting(request, response, callback, method, path)) {
                 return true;
             }
@@ -176,25 +178,38 @@ public class RequestHandler extends Handler.Abstract {
         }
 
         if (useVirtualThreads) {
-            Thread.startVirtualThread(() -> handleRequestAsync(request, requestBody, root, response, callback));
+            Thread.startVirtualThread(() -> handleRequestAsync(request, requestBody, jsonRpcMethod, response, callback));
         } else {
-            handleRequestAsync(request, requestBody, root, response, callback);
+            handleRequestAsync(request, requestBody, jsonRpcMethod, response, callback);
         }
         
         return true;
     }
 
-    private JsonNode attemptParsingRequestBodyAsJson(String method, byte[] requestBody) {
-        JsonNode root = null;
+    private String extractJsonRpcMethodFromBody(String method, byte[] requestBody) {
         if (POST.asString().equals(method) && requestBody != null) {
-            try {
-               root = objectMapper.readTree(requestBody);
+            try (JsonParser parser = objectMapper.getFactory().createParser(requestBody)) {
+                if (parser.nextToken() != JsonToken.START_OBJECT) {
+                    return null;
+                }
+
+                while (parser.nextToken() == JsonToken.FIELD_NAME) {
+                    String fieldName = parser.currentName();
+                    JsonToken valueToken = parser.nextToken();
+
+                    if ("method".equals(fieldName)) {
+                        return valueToken == JsonToken.VALUE_STRING ? parser.getText() : null;
+                    }
+
+                    parser.skipChildren();
+                }
             } catch (IOException e) {
-              // Non-JSON or invalid JSON content, will be treated as non-JSON-RPC request
-              logger.debug("Could not extract JSON method from request body", e);
+                // Non-JSON or invalid JSON content will be treated as a non-JSON-RPC request
+                // unless a method field was seen before the malformed part.
+                logger.debug("Could not extract JSON-RPC method from request body", e);
             }
         }
-        return root;
+        return null;
     }
 
     private boolean performValidationOnRequestSizeLimits(Request request, Response response, Callback callback) {
@@ -240,20 +255,15 @@ public class RequestHandler extends Handler.Abstract {
         return true;
     }
 
-    private boolean requiresAuthentication(String method, JsonNode root) {
-        boolean requiresAuth = false;
-        if (POST.asString().equals(method) && root != null) {
-            String jsonRpcMethod = extractJsonRpcMethodFromBody(root);
-            if (jsonRpcMethod != null && protectedMethods.contains(jsonRpcMethod)) {
-                requiresAuth = true;
-            }
-        }
-        return requiresAuth;
+    private boolean requiresAuthentication(String method, String jsonRpcMethod) {
+        return POST.asString().equals(method)
+            && jsonRpcMethod != null
+            && protectedMethods.contains(jsonRpcMethod);
     }
 
-    private void handleRequestAsync(Request request, byte[] cachedBody, JsonNode root, Response response, Callback callback) {
+    private void handleRequestAsync(Request request, byte[] cachedBody, String jsonRpcMethod, Response response, Callback callback) {
         try {
-            proxyRequest(request, cachedBody, root, response, callback);
+            proxyRequest(request, cachedBody, jsonRpcMethod, response, callback);
         } catch (Exception e) {
             logger.error("Error handling request", e);
             response.setStatus(HttpStatus.BAD_GATEWAY_502);
@@ -261,7 +271,7 @@ public class RequestHandler extends Handler.Abstract {
         }
     }
     
-    private void proxyRequest(Request request, byte[] cachedBody, JsonNode root, Response response, Callback callback) {
+    private void proxyRequest(Request request, byte[] cachedBody, String jsonRpcMethod, Response response, Callback callback) {
         try {
             String method = request.getMethod();
             String path = Request.getPathInContext(request);
@@ -271,7 +281,7 @@ public class RequestHandler extends Handler.Abstract {
             // Determine target URL based on routing parameters
             String targetUrl;
             try {
-                targetUrl = determineTargetUrl(request, root);
+                targetUrl = determineTargetUrl(request, cachedBody, jsonRpcMethod);
             } catch (IllegalArgumentException e) {
                 logger.warn("Invalid routing parameters: {}", e.getMessage());
                 response.setStatus(HttpStatus.BAD_REQUEST_400);
@@ -488,22 +498,17 @@ public class RequestHandler extends Handler.Abstract {
         }
     }
 
-    private String extractJsonRpcMethodFromBody(JsonNode root) {
+    private JsonNode parseRequestBodyAsJsonForRouting(byte[] requestBody) {
         try {
-            if (root.has("method")) {
-                return root.get("method").asText();
-            }
-        } catch (Exception e) {
-            logger.debug("Could not extract JSON-RPC method from request body", e);
+            return objectMapper.readTree(requestBody);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid JSON-RPC request body", e);
         }
-        return null;
     }
 
-    private RoutingParams extractRoutingParams(JsonNode root) {
+    private RoutingParams extractRoutingParams(JsonNode root, String method) {
         String stateId = null;
         String shardId = null;
-
-        String method = extractJsonRpcMethodFromBody(root);
 
         try {
             if (CERTIFICATION_REQUEST.equals(method) && root.has("params")) {
@@ -558,8 +563,15 @@ public class RequestHandler extends Handler.Abstract {
         }
     }
 
-    private boolean isJsonRpcRequest(JsonNode root) {
-        return root != null && root.has("method");
+    private RoutingParams extractRoutingParamsFromHeaders(Request request) {
+        String stateId = null;
+
+        var stateIdField = request.getHeaders().getField(HEADER_X_STATE_ID);
+        if (stateIdField != null && stateIdField.getValue() != null) {
+            stateId = stateIdField.getValue().trim();
+        }
+
+        return new RoutingParams(stateId, null);
     }
 
     private RoutingParams extractRoutingParamsFromCookies(Request request) {
@@ -620,19 +632,20 @@ public class RequestHandler extends Handler.Abstract {
         return shardRouter.getRandomTarget();
     }
 
-    private String determineTargetUrl(Request request, JsonNode root) throws IllegalArgumentException {
-        boolean isJsonRpc = isJsonRpcRequest(root);
+    private String determineTargetUrl(Request request, byte[] requestBody, String jsonRpcMethod) throws IllegalArgumentException {
+        boolean isJsonRpc = jsonRpcMethod != null;
 
-        RoutingParams params;
-        String rpcMethod = null;
-        if (isJsonRpc) {
-            params = extractRoutingParams(root);
-            rpcMethod = extractJsonRpcMethodFromBody(root);
-        } else {
-            params = extractRoutingParamsFromCookies(request);
+        RoutingParams headerParams = extractRoutingParamsFromHeaders(request);
+        if (headerParams.hasStateId()) {
+            return routeWithParams(headerParams, isJsonRpc, jsonRpcMethod);
         }
 
-        return routeWithParams(params, isJsonRpc, rpcMethod);
+        if (isJsonRpc) {
+            JsonNode root = parseRequestBodyAsJsonForRouting(requestBody);
+            return routeWithParams(extractRoutingParams(root, jsonRpcMethod), true, jsonRpcMethod);
+        }
+
+        return routeWithParams(extractRoutingParamsFromCookies(request), false, null);
     }
 
     ShardRouter getShardRouter() {

--- a/src/test/java/org/unicitylabs/proxy/ProxyServerIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/ProxyServerIntegrationTest.java
@@ -337,8 +337,8 @@ class ProxyServerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should not require authentication for malformed JSON targeting protected endpoint")
-    void testMalformedJsonForProtectedEndpointDoesNotRequireAuth() throws Exception {
+    @DisplayName("Should apply method-based auth when protected method is found before malformed JSON tail")
+    void testMalformedJsonForProtectedEndpointUsesExtractedMethodForAuth() throws Exception {
         String malformedJson = "{\"jsonrpc\":\"2.0\",\"method\":\"certification_request\",\"params\":\"815820" + "00".repeat(32) + "\","; // Missing closing brace
 
         HttpRequest request = getRequestBuilder("/", authMode)
@@ -348,10 +348,13 @@ class ProxyServerIntegrationTest extends AbstractIntegrationTest {
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
-        // Should be treated as non-JSON-RPC request (no auth required)
-        // The mock server will respond with OK since it receives the request
-        assertThat(response.statusCode()).isEqualTo(OK_200);
-        assertThat(response.body()).isEqualTo("OK");
+        if (authMode == AUTHORIZED) {
+            assertThat(response.statusCode()).isEqualTo(BAD_REQUEST_400);
+            assertThat(response.body()).contains("Invalid JSON-RPC request body");
+        } else {
+            assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED_401);
+            assertThat(response.body()).isEqualTo("Unauthorized");
+        }
     }
 
     @Test

--- a/src/test/java/org/unicitylabs/proxy/shard/BftShardRoutingIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/shard/BftShardRoutingIntegrationTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * prefix {@code "0"} (MSB=0) and one for shard prefix {@code "1"} (MSB=1).
  */
 public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
+    private static final String ZERO_STATE_ID = "00".repeat(32);
+    private static final String ONE_STATE_ID = "80" + "00".repeat(31);
     private static final String CERTIFICATION_REQUEST_PARAMS_HEX_WRONG_TAG =
         CERTIFICATION_REQUEST_PARAMS_HEX.replaceFirst("^d99876", "d99877");
     private static final String CERTIFICATION_REQUEST_PARAMS_HEX_WRONG_VERSION =
@@ -92,6 +94,18 @@ public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
         assertEquals(200, response.statusCode(),
             "expected 200, got " + response.statusCode() + " body: " + response.body());
         assertEquals("bft-1", shardLabel(response));
+    }
+
+    @Test
+    @DisplayName("certification_request routes by X-State-Id without decoding embedded params")
+    void certificationRequestRoutesByStateIdHeader() throws Exception {
+        HttpResponse<String> response = performJsonRpcRequest(
+            getAuthorizedRequestBuilder("/").header("X-State-Id", ZERO_STATE_ID),
+            certificationRequestJson(CERTIFICATION_REQUEST_PARAMS_HEX_WRONG_TAG));
+
+        assertEquals(200, response.statusCode(),
+            "expected 200, got " + response.statusCode() + " body: " + response.body());
+        assertEquals("bft-0", shardLabel(response));
     }
 
     @Test
@@ -170,6 +184,17 @@ public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("shard-bound v2 method routes by X-State-Id when body has no stateId")
+    void shardBoundV2RoutesByStateIdHeader() throws Exception {
+        HttpResponse<String> response = postJsonWithStateIdHeader(
+            jsonRpc("get_inclusion_proof.v2", "{}"), ONE_STATE_ID);
+
+        assertEquals(200, response.statusCode(),
+            "expected 200, got " + response.statusCode() + " body: " + response.body());
+        assertEquals("bft-1", shardLabel(response));
+    }
+
+    @Test
     @DisplayName("shard-bound v2 method with only shardId (no stateId) returns 400")
     void shardBoundV2WithOnlyShardIdReturns400() throws Exception {
         HttpResponse<String> response = postJsonNoStatusCheck(
@@ -237,6 +262,18 @@ public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
         HttpRequest request = HttpRequest.newBuilder()
             .uri(URI.create(getProxyUrl()))
             .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))
+            .timeout(Duration.ofSeconds(5))
+            .build();
+        return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> postJsonWithStateIdHeader(String jsonRpcRequest, String stateId)
+        throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(getProxyUrl()))
+            .header("Content-Type", "application/json")
+            .header("X-State-Id", stateId)
             .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))
             .timeout(Duration.ofSeconds(5))
             .build();

--- a/src/test/java/org/unicitylabs/proxy/shard/BftShardRoutingIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/shard/BftShardRoutingIntegrationTest.java
@@ -97,10 +97,10 @@ public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("certification_request routes by X-State-Id without decoding embedded params")
+    @DisplayName("certification_request routes by X-State-ID without decoding embedded params")
     void certificationRequestRoutesByStateIdHeader() throws Exception {
         HttpResponse<String> response = performJsonRpcRequest(
-            getAuthorizedRequestBuilder("/").header("X-State-Id", ZERO_STATE_ID),
+            getAuthorizedRequestBuilder("/").header("X-State-ID", ZERO_STATE_ID),
             certificationRequestJson(CERTIFICATION_REQUEST_PARAMS_HEX_WRONG_TAG));
 
         assertEquals(200, response.statusCode(),
@@ -184,7 +184,7 @@ public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("shard-bound v2 method routes by X-State-Id when body has no stateId")
+    @DisplayName("shard-bound v2 method routes by X-State-ID when body has no stateId")
     void shardBoundV2RoutesByStateIdHeader() throws Exception {
         HttpResponse<String> response = postJsonWithStateIdHeader(
             jsonRpc("get_inclusion_proof.v2", "{}"), ONE_STATE_ID);
@@ -273,7 +273,7 @@ public class BftShardRoutingIntegrationTest extends AbstractIntegrationTest {
         HttpRequest request = HttpRequest.newBuilder()
             .uri(URI.create(getProxyUrl()))
             .header("Content-Type", "application/json")
-            .header("X-State-Id", stateId)
+            .header("X-State-ID", stateId)
             .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))
             .timeout(Duration.ofSeconds(5))
             .build();


### PR DESCRIPTION
Adds `X-State-ID` HTTP header as a fast path for shard routing. When set, the gateway skips body JSON parsing and CBOR decoding entirely, only the JSON-RPC `method` field is streamed out (for auth), then the body is forwarded as-is