### PR TITLE
Expose Prometheus metrics on /metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.20.1'
     implementation 'com.google.guava:guava:33.5.0-jre'
 
+    implementation 'io.micrometer:micrometer-core:1.13.6'
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.13.6'
+
     testImplementation 'org.junit.jupiter:junit-jupiter:6.0.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.0.1'
     testImplementation 'org.assertj:assertj-core:3.27.6'

--- a/src/main/java/org/unicitylabs/proxy/ProxyServer.java
+++ b/src/main/java/org/unicitylabs/proxy/ProxyServer.java
@@ -275,6 +275,10 @@ public class ProxyServer {
         }
 
         server.stop();
+        // Release the meter registry's listeners (notably JvmGcMetrics' GC
+        // notification listener) — required when the same JVM constructs
+        // and tears down ProxyServer repeatedly.
+        metrics.close();
         logger.info("Proxy server stopped");
     }
     

--- a/src/main/java/org/unicitylabs/proxy/ProxyServer.java
+++ b/src/main/java/org/unicitylabs/proxy/ProxyServer.java
@@ -5,6 +5,8 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.unicitylabs.proxy.metrics.GatewayMetrics;
+import org.unicitylabs.proxy.metrics.MetricsHandler;
 import org.unicitylabs.proxy.repository.ShardConfigRepository;
 import org.unicitylabs.proxy.shard.*;
 import org.unicitylabs.proxy.util.EnvironmentProvider;
@@ -29,6 +31,7 @@ public class ProxyServer {
     private final ShardConfigRepository shardConfigRepository;
     private final ScheduledExecutorService configPoller;
     private final boolean validateShardConnectivity;
+    private final GatewayMetrics metrics;
 
     private volatile int lastConfigId;
 
@@ -56,8 +59,10 @@ public class ProxyServer {
 
         ShardRouter shardRouter = loadInitialShardConfiguration(config, environmentProvider);
 
-        this.requestHandler = new RequestHandler(config, shardRouter, databaseConfig);
+        this.metrics = new GatewayMetrics();
+        this.requestHandler = new RequestHandler(config, shardRouter, databaseConfig, metrics);
         this.rateLimiterManager = requestHandler.getRateLimiterManager();
+        metrics.registerRateLimitBucketGauge(rateLimiterManager, RateLimiterManager::getBucketCount);
 
         AdminHandler adminHandler = new AdminHandler(
             config.getAdminPassword(),
@@ -76,10 +81,15 @@ public class ProxyServer {
         // Create config handler for public config endpoints
         ConfigHandler configHandler = new ConfigHandler(shardConfigRepository);
 
-        // Create a combined handler that tries handlers in order: health, config, payment, admin, then proxy
+        MetricsHandler metricsHandler = new MetricsHandler(metrics);
+
+        // Create a combined handler that tries handlers in order: metrics, health, config, payment, admin, then proxy
         Handler.Abstract combinedHandler = new Handler.Abstract() {
             @Override
             public boolean handle(Request request, Response response, Callback callback) throws Exception {
+                if (metricsHandler.handle(request, response, callback)) {
+                    return true;
+                }
                 // Try health check first (for /health endpoint)
                 if (healthCheckHandler.handle(request, response, callback)) {
                     return true;

--- a/src/main/java/org/unicitylabs/proxy/ProxyServer.java
+++ b/src/main/java/org/unicitylabs/proxy/ProxyServer.java
@@ -310,8 +310,9 @@ public class ProxyServer {
     /**
      * Build a stable URL → shard-label map for Prometheus labels. App-shard
      * targets get {@code shard-<id>}; bft-shard targets get
-     * {@code shard-<prefix>} (or {@code shard-default} for an empty prefix).
-     * Duplicate URLs across shards keep the first label seen.
+     * {@code shard-<prefix>}. Duplicate URLs across shards keep the first
+     * label seen. {@code BftShardInfo} validates at construction that prefix
+     * is non-blank, so no empty-prefix handling is needed here.
      */
     static Map<String, String> buildShardLabels(ShardConfig config) {
         Map<String, String> labels = new LinkedHashMap<>();
@@ -326,8 +327,7 @@ public class ProxyServer {
         if (config.getBftShards() != null) {
             for (BftShardInfo s : config.getBftShards()) {
                 if (s.url() != null) {
-                    String prefix = s.prefix() == null || s.prefix().isBlank() ? "default" : s.prefix();
-                    labels.putIfAbsent(s.url(), "shard-" + prefix);
+                    labels.putIfAbsent(s.url(), "shard-" + s.prefix());
                 }
             }
         }

--- a/src/main/java/org/unicitylabs/proxy/ProxyServer.java
+++ b/src/main/java/org/unicitylabs/proxy/ProxyServer.java
@@ -12,6 +12,8 @@ import org.unicitylabs.proxy.shard.*;
 import org.unicitylabs.proxy.util.EnvironmentProvider;
 import org.unicitylabs.proxy.util.ResourceLoader;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -57,9 +59,9 @@ public class ProxyServer {
         ServerConnector connector = getServerConnector(config);
         server.addConnector(connector);
 
+        this.metrics = new GatewayMetrics();
         ShardRouter shardRouter = loadInitialShardConfiguration(config, environmentProvider);
 
-        this.metrics = new GatewayMetrics();
         this.requestHandler = new RequestHandler(config, shardRouter, databaseConfig, metrics);
         this.rateLimiterManager = requestHandler.getRateLimiterManager();
         metrics.registerRateLimitBucketGauge(rateLimiterManager, RateLimiterManager::getBucketCount);
@@ -145,6 +147,7 @@ public class ProxyServer {
             ShardConfigValidator.validate(tempRouter, configRecord.config(), validateShardConnectivity);
             this.lastConfigId = configRecord.id();
             shardRouter = tempRouter;
+            metrics.setShardLabels(buildShardLabels(configRecord.config()));
             logger.info("Shard configuration loaded and validated successfully (mode: {}, id: {}, created at: {})",
                 configRecord.config().getMode(), configRecord.id(), configRecord.createdAt());
         } catch (Exception e) {
@@ -173,6 +176,7 @@ public class ProxyServer {
             int insertedId = shardConfigRepository.saveConfig(shardConfig, "environment");
             this.lastConfigId = insertedId;
             shardRouter = tempRouter;
+            metrics.setShardLabels(buildShardLabels(shardConfig));
 
             logger.info("Shard configuration loaded from {} and saved to database (id: {})", configUri, insertedId);
         } catch (Exception e) {
@@ -198,6 +202,7 @@ public class ProxyServer {
 
                         requestHandler.updateShardRouter(newRouter);
                         paymentHandler.updateShardRouter(newRouter);
+                        metrics.setShardLabels(buildShardLabels(latestRecord.config()));
                         lastConfigId = latestRecord.id();
 
                         logger.info("Shard configuration hot-reloaded successfully (mode: {}, id: {}) with {} targets",
@@ -300,5 +305,32 @@ public class ProxyServer {
 
     public ShardRouter getShardRouter() {
         return this.requestHandler.getShardRouter();
+    }
+
+    /**
+     * Build a stable URL → shard-label map for Prometheus labels. App-shard
+     * targets get {@code shard-<id>}; bft-shard targets get
+     * {@code shard-<prefix>} (or {@code shard-default} for an empty prefix).
+     * Duplicate URLs across shards keep the first label seen.
+     */
+    static Map<String, String> buildShardLabels(ShardConfig config) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        if (config == null) return labels;
+        if (config.getShards() != null) {
+            for (ShardInfo s : config.getShards()) {
+                if (s.url() != null) {
+                    labels.putIfAbsent(s.url(), "shard-" + s.id());
+                }
+            }
+        }
+        if (config.getBftShards() != null) {
+            for (BftShardInfo s : config.getBftShards()) {
+                if (s.url() != null) {
+                    String prefix = s.prefix() == null || s.prefix().isBlank() ? "default" : s.prefix();
+                    labels.putIfAbsent(s.url(), "shard-" + prefix);
+                }
+            }
+        }
+        return labels;
     }
 }

--- a/src/main/java/org/unicitylabs/proxy/RateLimiterManager.java
+++ b/src/main/java/org/unicitylabs/proxy/RateLimiterManager.java
@@ -30,6 +30,10 @@ public class RateLimiterManager {
         buckets.clear();
     }
 
+    public int getBucketCount() {
+        return buckets.size();
+    }
+
     public RateLimitResult tryConsume(String apiKey) {
         CachedApiKeyManager.ApiKeyInfo currentApiKeyInfo = apiKeyManager.getApiKeyInfo(apiKey);
         if (currentApiKeyInfo == null) {

--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -1,5 +1,7 @@
 package org.unicitylabs.proxy;
 
+import org.unicitylabs.proxy.metrics.GatewayMetrics;
+import org.unicitylabs.proxy.metrics.GatewayMetrics.Outcome;
 import org.unicitylabs.proxy.model.ObjectMapperUtils;
 import org.unicitylabs.proxy.shard.ShardRouter;
 import org.eclipse.jetty.http.HttpField;
@@ -101,8 +103,14 @@ public class RequestHandler extends Handler.Abstract {
     private final WebUIHandler webUIHandler;
     private final Set<String> protectedMethods;
     private final ObjectMapper objectMapper = ObjectMapperUtils.createObjectMapper();
+    private final GatewayMetrics metrics;
 
     public RequestHandler(ProxyConfig config, ShardRouter shardRouter, org.unicitylabs.proxy.repository.DatabaseConfig databaseConfig) {
+        this(config, shardRouter, databaseConfig, new GatewayMetrics());
+    }
+
+    public RequestHandler(ProxyConfig config, ShardRouter shardRouter, org.unicitylabs.proxy.repository.DatabaseConfig databaseConfig, GatewayMetrics metrics) {
+        this.metrics = metrics;
         this.shardRouter = shardRouter;
         this.readTimeout = Duration.ofMillis(config.getReadTimeout());
         this.useVirtualThreads = config.isVirtualThreads();
@@ -146,18 +154,21 @@ public class RequestHandler extends Handler.Abstract {
         // Add CORS headers to all responses
         CorsUtils.addCorsHeaders(request, response, HEADER_X_RATE_LIMIT_REMAINING);
 
+        RequestMetricsRecorder recorder = new RequestMetricsRecorder(metrics, response);
+        Callback metricsCallback = recorder.wrap(callback);
+
         // Handle CORS preflight OPTIONS requests
         if (OPTIONS.asString().equals(method)) {
             response.setStatus(HttpStatus.NO_CONTENT_204);
-            callback.succeeded();
+            metricsCallback.succeeded();
             return true;
         }
 
         // Handle web UI routes
         if ("/index.html".equals(path) || "/generate".equals(path)) {
-            return webUIHandler.handle(request, response, callback);
+            return webUIHandler.handle(request, response, metricsCallback);
         }
-        
+
         byte[] requestBody;
         if (hasBody(request.getMethod())) {
             requestBody = readBodyWithLimit(request);
@@ -166,23 +177,24 @@ public class RequestHandler extends Handler.Abstract {
         }
 
         String jsonRpcMethod = extractJsonRpcMethodFromBody(method, requestBody);
+        recorder.setJsonRpcMethod(jsonRpcMethod);
 
         if (requiresAuthentication(request.getMethod(), jsonRpcMethod)) {
-            if (!performAuthenticationAndRateLimiting(request, response, callback, method, path)) {
+            if (!performAuthenticationAndRateLimiting(request, response, metricsCallback, method, path, recorder)) {
                 return true;
             }
         }
 
-        if (!performValidationOnRequestSizeLimits(request, response, callback)) {
+        if (!performValidationOnRequestSizeLimits(request, response, metricsCallback, recorder)) {
             return true;
         }
 
         if (useVirtualThreads) {
-            Thread.startVirtualThread(() -> handleRequestAsync(request, requestBody, jsonRpcMethod, response, callback));
+            Thread.startVirtualThread(() -> handleRequestAsync(request, requestBody, jsonRpcMethod, response, metricsCallback, recorder));
         } else {
-            handleRequestAsync(request, requestBody, jsonRpcMethod, response, callback);
+            handleRequestAsync(request, requestBody, jsonRpcMethod, response, metricsCallback, recorder);
         }
-        
+
         return true;
     }
 
@@ -212,10 +224,11 @@ public class RequestHandler extends Handler.Abstract {
         return null;
     }
 
-    private boolean performValidationOnRequestSizeLimits(Request request, Response response, Callback callback) {
+    private boolean performValidationOnRequestSizeLimits(Request request, Response response, Callback callback, RequestMetricsRecorder recorder) {
         String validationError = validateRequestSizeLimits(request);
         if (validationError != null) {
             logger.warn("Request validation failed: {}", validationError);
+            recorder.setOutcome(Outcome.BAD_REQUEST);
             response.setStatus(HttpStatus.BAD_REQUEST_400);
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, TEXT_PLAIN.asString());
             response.write(true, ByteBuffer.wrap(validationError.getBytes()), callback);
@@ -224,11 +237,12 @@ public class RequestHandler extends Handler.Abstract {
         return true;
     }
 
-    private boolean performAuthenticationAndRateLimiting(Request request, Response response, Callback callback, String method, String path) {
+    private boolean performAuthenticationAndRateLimiting(Request request, Response response, Callback callback, String method, String path, RequestMetricsRecorder recorder) {
         String apiKey = extractApiKey(request);
         if (apiKey == null || !apiKeyManager.isValidApiKey(apiKey)) {
             logger.warn("Authentication failed for request: {} {} - API key: {}", method, path,
                     apiKey != null ? "invalid" : "missing");
+            recorder.setOutcome(Outcome.UNAUTHORIZED);
             response.setStatus(HttpStatus.UNAUTHORIZED_401);
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, TEXT_PLAIN.asString());
             response.getHeaders().put(HttpHeader.WWW_AUTHENTICATE, BEARER_AUTHORIZATION);
@@ -244,6 +258,7 @@ public class RequestHandler extends Handler.Abstract {
         RateLimiterManager.RateLimitResult rateLimitResult = rateLimiterManager.tryConsume(apiKey);
         if (!rateLimitResult.allowed()) {
             logger.info("Rate limit exceeded for API key: {}", apiKey);
+            recorder.setOutcome(Outcome.RATE_LIMITED);
             response.setStatus(HttpStatus.TOO_MANY_REQUESTS_429);
             response.getHeaders().put(HttpHeader.CONTENT_TYPE, TEXT_PLAIN.asString());
             response.getHeaders().put(RETRY_AFTER, String.valueOf(rateLimitResult.retryAfterSeconds()));
@@ -261,17 +276,18 @@ public class RequestHandler extends Handler.Abstract {
             && protectedMethods.contains(jsonRpcMethod);
     }
 
-    private void handleRequestAsync(Request request, byte[] cachedBody, String jsonRpcMethod, Response response, Callback callback) {
+    private void handleRequestAsync(Request request, byte[] cachedBody, String jsonRpcMethod, Response response, Callback callback, RequestMetricsRecorder recorder) {
         try {
-            proxyRequest(request, cachedBody, jsonRpcMethod, response, callback);
+            proxyRequest(request, cachedBody, jsonRpcMethod, response, callback, recorder);
         } catch (Exception e) {
             logger.error("Error handling request", e);
+            recorder.setOutcome(Outcome.UPSTREAM_ERROR);
             response.setStatus(HttpStatus.BAD_GATEWAY_502);
             response.write(true, ByteBuffer.wrap("Bad Gateway".getBytes()), callback);
         }
     }
-    
-    private void proxyRequest(Request request, byte[] cachedBody, String jsonRpcMethod, Response response, Callback callback) {
+
+    private void proxyRequest(Request request, byte[] cachedBody, String jsonRpcMethod, Response response, Callback callback, RequestMetricsRecorder recorder) {
         try {
             String method = request.getMethod();
             String path = Request.getPathInContext(request);
@@ -284,6 +300,7 @@ public class RequestHandler extends Handler.Abstract {
                 targetUrl = determineTargetUrl(request, cachedBody, jsonRpcMethod);
             } catch (IllegalArgumentException e) {
                 logger.warn("Invalid routing parameters: {}", e.getMessage());
+                recorder.setOutcome(Outcome.ROUTING_ERROR);
                 response.setStatus(HttpStatus.BAD_REQUEST_400);
                 String errorBody = routingErrorBody(e.getMessage());
                 response.write(true, ByteBuffer.wrap(errorBody.getBytes()), callback);
@@ -309,16 +326,20 @@ public class RequestHandler extends Handler.Abstract {
                 .whenComplete((httpResponse, throwable) -> {
                     if (throwable != null) {
                         logger.error("Failed to proxy request to {}: {}", targetUri, throwable.getMessage());
+                        metrics.recordUpstream(targetUrl, false);
+                        recorder.setOutcome(Outcome.UPSTREAM_ERROR);
                         handleError(response, callback, throwable);
                     } else {
                         if (logger.isDebugEnabled()) {
                             logger.debug("Received response from {}: status {}", targetUri, httpResponse.statusCode());
                         }
+                        metrics.recordUpstream(targetUrl, httpResponse.statusCode() < 500);
                         forwardResponse(response, callback, httpResponse);
                     }
                 });
-            
+
         } catch (Exception e) {
+            recorder.setOutcome(Outcome.UPSTREAM_ERROR);
             handleError(response, callback, e);
         }
     }
@@ -656,5 +677,49 @@ public class RequestHandler extends Handler.Abstract {
         String cleanBase = baseUrl.replaceAll("/+$", "");
         String cleanPath = path.replaceAll("^/+", "");
         return URI.create(cleanBase + "/" + cleanPath).toString();
+    }
+
+    /**
+     * Per-request metrics state. Mutated as the request flows through the
+     * handler; recorded once when the response callback completes.
+     */
+    static final class RequestMetricsRecorder {
+        private final GatewayMetrics metrics;
+        private final Response response;
+        private final long startNanos = System.nanoTime();
+        private final java.util.concurrent.atomic.AtomicBoolean recorded = new java.util.concurrent.atomic.AtomicBoolean();
+        private volatile String jsonRpcMethod;
+        private volatile Outcome outcome = Outcome.SUCCESS;
+
+        RequestMetricsRecorder(GatewayMetrics metrics, Response response) {
+            this.metrics = metrics;
+            this.response = response;
+        }
+
+        void setJsonRpcMethod(String method) { this.jsonRpcMethod = method; }
+        void setOutcome(Outcome outcome) { this.outcome = outcome; }
+
+        Callback wrap(Callback delegate) {
+            return new Callback() {
+                @Override
+                public void succeeded() {
+                    recordOnce();
+                    delegate.succeeded();
+                }
+
+                @Override
+                public void failed(Throwable x) {
+                    recordOnce();
+                    delegate.failed(x);
+                }
+            };
+        }
+
+        private void recordOnce() {
+            if (recorded.compareAndSet(false, true)) {
+                long elapsed = System.nanoTime() - startNanos;
+                metrics.recordRequest(outcome, jsonRpcMethod, response.getStatus(), elapsed);
+            }
+        }
     }
 }

--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -177,7 +177,20 @@ public class RequestHandler extends Handler.Abstract {
 
         byte[] requestBody;
         if (hasBody(request.getMethod())) {
-            requestBody = readBodyWithLimit(request);
+            try {
+                requestBody = readBodyWithLimit(request);
+            } catch (IOException e) {
+                // Client transport failed mid-body. Without this catch, the
+                // exception bubbles out of handle(), Jetty's default error
+                // path runs, and our wrapped callback never fires — so the
+                // request is missing from gateway_requests_total.
+                logger.warn("Failed to read request body: {}", e.getMessage());
+                recorder.setOutcome(Outcome.BAD_REQUEST);
+                response.setStatus(HttpStatus.BAD_REQUEST_400);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, TEXT_PLAIN.asString());
+                response.write(true, ByteBuffer.wrap("Failed to read request body".getBytes()), metricsCallback);
+                return true;
+            }
         } else {
             requestBody = null;
         }

--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -105,7 +105,13 @@ public class RequestHandler extends Handler.Abstract {
     private final ObjectMapper objectMapper = ObjectMapperUtils.createObjectMapper();
     private final GatewayMetrics metrics;
 
-    public RequestHandler(ProxyConfig config, ShardRouter shardRouter, org.unicitylabs.proxy.repository.DatabaseConfig databaseConfig) {
+    /**
+     * Test-only convenience constructor: spins up a throwaway
+     * {@link GatewayMetrics} (with its own JVM/system binders). Production
+     * code must use the 4-arg constructor with a shared {@code GatewayMetrics}
+     * to avoid duplicate metric registrations.
+     */
+    RequestHandler(ProxyConfig config, ShardRouter shardRouter, org.unicitylabs.proxy.repository.DatabaseConfig databaseConfig) {
         this(config, shardRouter, databaseConfig, new GatewayMetrics());
     }
 

--- a/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
@@ -30,7 +30,7 @@ import java.util.function.ToDoubleFunction;
  * the request-duration timer is applied globally via a {@link MeterFilter}
  * registered at construction time.
  */
-public final class GatewayMetrics {
+public final class GatewayMetrics implements AutoCloseable {
 
     public enum Outcome {
         SUCCESS("success"),
@@ -71,6 +71,7 @@ public final class GatewayMetrics {
     );
 
     private final PrometheusMeterRegistry registry;
+    private final JvmGcMetrics jvmGcMetrics;
     private final ConcurrentHashMap<RequestKey, Counter> requestCounters = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<TimerKey, Timer> requestTimers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UpstreamKey, Counter> upstreamCounters = new ConcurrentHashMap<>();
@@ -97,11 +98,22 @@ public final class GatewayMetrics {
         });
 
         new JvmMemoryMetrics().bindTo(registry);
-        new JvmGcMetrics().bindTo(registry);
+        // JvmGcMetrics installs a GC notification listener and must be
+        // closed when the registry is torn down — otherwise repeated
+        // ProxyServer construction (tests, embedded use, in-JVM rolling
+        // restarts) accumulates listeners.
+        this.jvmGcMetrics = new JvmGcMetrics();
+        jvmGcMetrics.bindTo(registry);
         new JvmThreadMetrics().bindTo(registry);
         new ProcessorMetrics().bindTo(registry);
         new UptimeMetrics().bindTo(registry);
         new FileDescriptorMetrics().bindTo(registry);
+    }
+
+    @Override
+    public void close() {
+        jvmGcMetrics.close();
+        registry.close();
     }
 
     public PrometheusMeterRegistry registry() {
@@ -184,13 +196,17 @@ public final class GatewayMetrics {
         return KNOWN_METHODS.contains(method) ? method : METHOD_OTHER;
     }
 
+    /**
+     * Maps the response status to its standard class label. The proxy
+     * disables redirect following but forwards 3xx upstream responses
+     * unchanged, so 3xx is exposed as its own class for visibility — folding
+     * it into 2xx would hide redirects from dashboards/alerts. The full
+     * label set is {@code {2xx, 3xx, 4xx, 5xx, other}}.
+     */
     private static String statusClass(int status) {
         if (status >= 500) return "5xx";
         if (status >= 400) return "4xx";
-        // 3xx upstream responses fold into 2xx — the proxy disables redirect
-        // following, so any 3xx received is forwarded as-is and is treated as a
-        // successful upstream interaction. Keeping the documented three-class
-        // schema ({2xx,4xx,5xx}) keeps dashboards/alerts stable.
+        if (status >= 300) return "3xx";
         if (status >= 200) return "2xx";
         return "other";
     }

--- a/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
@@ -1,0 +1,126 @@
+package org.unicitylabs.proxy.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+
+import java.util.Set;
+import java.util.function.ToDoubleFunction;
+
+/**
+ * Gateway-wide metrics registry. Holds the Prometheus registry, JVM/system
+ * binders, and the gateway-specific counters/timers used by the request path.
+ */
+public final class GatewayMetrics {
+
+    public enum Outcome {
+        SUCCESS("success"),
+        UNAUTHORIZED("unauthorized"),
+        RATE_LIMITED("rate_limited"),
+        BAD_REQUEST("bad_request"),
+        ROUTING_ERROR("routing_error"),
+        UPSTREAM_ERROR("upstream_error");
+
+        private final String label;
+
+        Outcome(String label) { this.label = label; }
+
+        public String label() { return label; }
+    }
+
+    private static final String METHOD_NONE = "none";
+    private static final String METHOD_OTHER = "other";
+
+    /**
+     * Methods we expect to see; anything outside this set is collapsed to
+     * "other" to keep label cardinality bounded.
+     */
+    private static final Set<String> KNOWN_METHODS = Set.of(
+        "submit_commitment",
+        "get_inclusion_proof",
+        "get_inclusion_proof.v2",
+        "get_no_deletion_proof",
+        "get_block_height",
+        "get_block",
+        "get_block_commitments",
+        "certification_request"
+    );
+
+    private final PrometheusMeterRegistry registry;
+
+    public GatewayMetrics() {
+        this.registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmGcMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        new UptimeMetrics().bindTo(registry);
+        new FileDescriptorMetrics().bindTo(registry);
+    }
+
+    public PrometheusMeterRegistry registry() {
+        return registry;
+    }
+
+    public String scrape() {
+        return registry.scrape();
+    }
+
+    public void recordRequest(Outcome outcome, String jsonRpcMethod, int httpStatus, long durationNanos) {
+        String method = normalizeMethod(jsonRpcMethod);
+        String statusClass = statusClass(httpStatus);
+        Counter.builder("gateway_requests_total")
+            .description("Total HTTP requests processed by the gateway")
+            .tag("outcome", outcome.label())
+            .tag("jsonrpc_method", method)
+            .tag("status_class", statusClass)
+            .register(registry)
+            .increment();
+
+        Timer.builder("gateway_request_duration_seconds")
+            .description("End-to-end request latency, including upstream call")
+            .tag("outcome", outcome.label())
+            .tag("jsonrpc_method", method)
+            .publishPercentileHistogram()
+            .register(registry)
+            .record(durationNanos, java.util.concurrent.TimeUnit.NANOSECONDS);
+    }
+
+    public void recordUpstream(String shardTarget, boolean success) {
+        Counter.builder("gateway_upstream_requests_total")
+            .description("Requests forwarded to upstream aggregator shards")
+            .tag("shard", shardTarget == null ? "unknown" : shardTarget)
+            .tag("outcome", success ? "success" : "error")
+            .register(registry)
+            .increment();
+    }
+
+    public <T> void registerRateLimitBucketGauge(T source, ToDoubleFunction<T> sizeFn) {
+        io.micrometer.core.instrument.Gauge.builder("gateway_ratelimit_buckets", source, sizeFn)
+            .description("Number of active per-API-key rate-limit buckets")
+            .register(registry);
+    }
+
+    private static String normalizeMethod(String method) {
+        if (method == null || method.isBlank()) {
+            return METHOD_NONE;
+        }
+        return KNOWN_METHODS.contains(method) ? method : METHOD_OTHER;
+    }
+
+    private static String statusClass(int status) {
+        if (status >= 500) return "5xx";
+        if (status >= 400) return "4xx";
+        if (status >= 300) return "3xx";
+        if (status >= 200) return "2xx";
+        return "other";
+    }
+}

--- a/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
@@ -1,7 +1,7 @@
 package org.unicitylabs.proxy.metrics;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
@@ -9,15 +9,26 @@ import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.ToDoubleFunction;
 
 /**
  * Gateway-wide metrics registry. Holds the Prometheus registry, JVM/system
  * binders, and the gateway-specific counters/timers used by the request path.
+ *
+ * <p>Hot-path instruments ({@link #recordRequest} / {@link #recordUpstream})
+ * are cached in {@link ConcurrentHashMap}s keyed by tag tuples to avoid
+ * builder/register overhead on every request. Histogram configuration for
+ * the request-duration timer is applied globally via a {@link MeterFilter}
+ * registered at construction time.
  */
 public final class GatewayMetrics {
 
@@ -38,6 +49,11 @@ public final class GatewayMetrics {
 
     private static final String METHOD_NONE = "none";
     private static final String METHOD_OTHER = "other";
+    private static final String SHARD_UNKNOWN = "unknown";
+
+    static final String REQUESTS_METRIC = "gateway_requests_total";
+    static final String DURATION_METRIC = "gateway_request_duration_seconds";
+    static final String UPSTREAM_METRIC = "gateway_upstream_requests_total";
 
     /**
      * Methods we expect to see; anything outside this set is collapsed to
@@ -55,9 +71,31 @@ public final class GatewayMetrics {
     );
 
     private final PrometheusMeterRegistry registry;
+    private final ConcurrentHashMap<RequestKey, Counter> requestCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<TimerKey, Timer> requestTimers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UpstreamKey, Counter> upstreamCounters = new ConcurrentHashMap<>();
+
+    /** URL → stable shard label (e.g. "shard-0"); replaced atomically on shard-config reload. */
+    private volatile Map<String, String> shardLabels = Collections.emptyMap();
 
     public GatewayMetrics() {
         this.registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+
+        // Configure the request-duration histogram once, globally — avoids
+        // re-evaluating distribution config on every recordRequest() call.
+        registry.config().meterFilter(new MeterFilter() {
+            @Override
+            public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+                if (DURATION_METRIC.equals(id.getName())) {
+                    return DistributionStatisticConfig.builder()
+                        .percentilesHistogram(true)
+                        .build()
+                        .merge(config);
+                }
+                return config;
+            }
+        });
+
         new JvmMemoryMetrics().bindTo(registry);
         new JvmGcMetrics().bindTo(registry);
         new JvmThreadMetrics().bindTo(registry);
@@ -74,39 +112,67 @@ public final class GatewayMetrics {
         return registry.scrape();
     }
 
+    /**
+     * Replace the URL-to-shard-label mapping. Called by the proxy at startup
+     * and on shard-config hot-reload. Labels not present in the map are
+     * reported as {@code "unknown"} on {@link #recordUpstream}.
+     */
+    public void setShardLabels(Map<String, String> labels) {
+        this.shardLabels = labels == null ? Collections.emptyMap() : Map.copyOf(labels);
+    }
+
     public void recordRequest(Outcome outcome, String jsonRpcMethod, int httpStatus, long durationNanos) {
         String method = normalizeMethod(jsonRpcMethod);
         String statusClass = statusClass(httpStatus);
-        Counter.builder("gateway_requests_total")
-            .description("Total HTTP requests processed by the gateway")
-            .tag("outcome", outcome.label())
-            .tag("jsonrpc_method", method)
-            .tag("status_class", statusClass)
-            .register(registry)
-            .increment();
+        RequestKey rk = new RequestKey(outcome, method, statusClass);
+        requestCounters.computeIfAbsent(rk, this::newRequestCounter).increment();
 
-        Timer.builder("gateway_request_duration_seconds")
-            .description("End-to-end request latency, including upstream call")
-            .tag("outcome", outcome.label())
-            .tag("jsonrpc_method", method)
-            .publishPercentileHistogram()
-            .register(registry)
+        TimerKey tk = new TimerKey(outcome, method);
+        requestTimers.computeIfAbsent(tk, this::newRequestTimer)
             .record(durationNanos, java.util.concurrent.TimeUnit.NANOSECONDS);
     }
 
     public void recordUpstream(String shardTarget, boolean success) {
-        Counter.builder("gateway_upstream_requests_total")
-            .description("Requests forwarded to upstream aggregator shards")
-            .tag("shard", shardTarget == null ? "unknown" : shardTarget)
-            .tag("outcome", success ? "success" : "error")
-            .register(registry)
-            .increment();
+        String label = resolveShardLabel(shardTarget);
+        UpstreamKey key = new UpstreamKey(label, success);
+        upstreamCounters.computeIfAbsent(key, this::newUpstreamCounter).increment();
     }
 
     public <T> void registerRateLimitBucketGauge(T source, ToDoubleFunction<T> sizeFn) {
         io.micrometer.core.instrument.Gauge.builder("gateway_ratelimit_buckets", source, sizeFn)
             .description("Number of active per-API-key rate-limit buckets")
             .register(registry);
+    }
+
+    private Counter newRequestCounter(RequestKey k) {
+        return Counter.builder(REQUESTS_METRIC)
+            .description("Total HTTP requests processed by the gateway")
+            .tag("outcome", k.outcome.label())
+            .tag("jsonrpc_method", k.method)
+            .tag("status_class", k.statusClass)
+            .register(registry);
+    }
+
+    private Timer newRequestTimer(TimerKey k) {
+        return Timer.builder(DURATION_METRIC)
+            .description("End-to-end request latency, including upstream call")
+            .tag("outcome", k.outcome.label())
+            .tag("jsonrpc_method", k.method)
+            .register(registry);
+    }
+
+    private Counter newUpstreamCounter(UpstreamKey k) {
+        return Counter.builder(UPSTREAM_METRIC)
+            .description("Requests forwarded to upstream aggregator shards")
+            .tag("shard", k.shardLabel)
+            .tag("outcome", k.success ? "success" : "error")
+            .register(registry);
+    }
+
+    private String resolveShardLabel(String shardTarget) {
+        if (shardTarget == null) return SHARD_UNKNOWN;
+        String label = shardLabels.get(shardTarget);
+        return label != null ? label : SHARD_UNKNOWN;
     }
 
     private static String normalizeMethod(String method) {
@@ -123,4 +189,8 @@ public final class GatewayMetrics {
         if (status >= 200) return "2xx";
         return "other";
     }
+
+    private record RequestKey(Outcome outcome, String method, String statusClass) {}
+    private record TimerKey(Outcome outcome, String method) {}
+    private record UpstreamKey(String shardLabel, boolean success) {}
 }

--- a/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
@@ -140,7 +140,9 @@ public final class GatewayMetrics {
 
     public <T> void registerRateLimitBucketGauge(T source, ToDoubleFunction<T> sizeFn) {
         io.micrometer.core.instrument.Gauge.builder("gateway_ratelimit_buckets", source, sizeFn)
-            .description("Number of active per-API-key rate-limit buckets")
+            .description("Per-API-key rate-limit buckets currently held in memory. " +
+                "Buckets are created on first use and not evicted, so the value " +
+                "approximates the count of distinct API keys seen since startup.")
             .register(registry);
     }
 
@@ -185,7 +187,10 @@ public final class GatewayMetrics {
     private static String statusClass(int status) {
         if (status >= 500) return "5xx";
         if (status >= 400) return "4xx";
-        if (status >= 300) return "3xx";
+        // 3xx upstream responses fold into 2xx — the proxy disables redirect
+        // following, so any 3xx received is forwarded as-is and is treated as a
+        // successful upstream interaction. Keeping the documented three-class
+        // schema ({2xx,4xx,5xx}) keeps dashboards/alerts stable.
         if (status >= 200) return "2xx";
         return "other";
     }

--- a/src/main/java/org/unicitylabs/proxy/metrics/MetricsHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/MetricsHandler.java
@@ -1,0 +1,34 @@
+package org.unicitylabs.proxy.metrics;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+public class MetricsHandler extends Handler.Abstract {
+    public static final String PATH = "/metrics";
+    private static final String CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+    private final GatewayMetrics metrics;
+
+    public MetricsHandler(GatewayMetrics metrics) {
+        this.metrics = metrics;
+    }
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback) {
+        if (!PATH.equals(request.getHttpURI().getPath())) {
+            return false;
+        }
+        byte[] body = metrics.scrape().getBytes(StandardCharsets.UTF_8);
+        response.setStatus(HttpStatus.OK_200);
+        response.getHeaders().put(HttpHeader.CONTENT_TYPE, CONTENT_TYPE);
+        response.write(true, ByteBuffer.wrap(body), callback);
+        return true;
+    }
+}

--- a/src/main/java/org/unicitylabs/proxy/metrics/MetricsHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/MetricsHandler.java
@@ -1,6 +1,7 @@
 package org.unicitylabs.proxy.metrics;
 
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -24,6 +25,12 @@ public class MetricsHandler extends Handler.Abstract {
     public boolean handle(Request request, Response response, Callback callback) {
         if (!PATH.equals(request.getHttpURI().getPath())) {
             return false;
+        }
+        if (!HttpMethod.GET.is(request.getMethod())) {
+            response.setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);
+            response.getHeaders().put(HttpHeader.ALLOW, "GET");
+            callback.succeeded();
+            return true;
         }
         byte[] body = metrics.scrape().getBytes(StandardCharsets.UTF_8);
         response.setStatus(HttpStatus.OK_200);

--- a/src/test/java/org/unicitylabs/proxy/ShardLabelMappingTest.java
+++ b/src/test/java/org/unicitylabs/proxy/ShardLabelMappingTest.java
@@ -1,0 +1,73 @@
+package org.unicitylabs.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.unicitylabs.proxy.shard.BftShardInfo;
+import org.unicitylabs.proxy.shard.ShardConfig;
+import org.unicitylabs.proxy.shard.ShardInfo;
+import org.unicitylabs.proxy.shard.ShardingMode;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Coverage for {@link ProxyServer#buildShardLabels(ShardConfig)}. Each Prometheus
+ * upstream label originates from this map; a regression here silently turns
+ * upstream metrics into {@code shard="unknown"} in production.
+ */
+class ShardLabelMappingTest {
+
+    @Test
+    void appShardLabelsKeyByShardId() {
+        ShardConfig config = new ShardConfig(1, List.of(
+            new ShardInfo(0, "http://shard-a:3000"),
+            new ShardInfo(1, "http://shard-b:3000")
+        ));
+
+        Map<String, String> labels = ProxyServer.buildShardLabels(config);
+
+        assertThat(labels).containsExactlyInAnyOrderEntriesOf(Map.of(
+            "http://shard-a:3000", "shard-0",
+            "http://shard-b:3000", "shard-1"
+        ));
+    }
+
+    @Test
+    void bftShardLabelsKeyByPrefix() {
+        ShardConfig config = new ShardConfig(1, ShardingMode.BFT_SHARD, List.of(),
+            List.of(
+                new BftShardInfo("0", "http://bft-zero:3000"),
+                new BftShardInfo("10", "http://bft-ten:3000"),
+                new BftShardInfo("11", "http://bft-eleven:3000")
+            ));
+
+        Map<String, String> labels = ProxyServer.buildShardLabels(config);
+
+        assertThat(labels).containsExactlyInAnyOrderEntriesOf(Map.of(
+            "http://bft-zero:3000", "shard-0",
+            "http://bft-ten:3000", "shard-10",
+            "http://bft-eleven:3000", "shard-11"
+        ));
+    }
+
+    @Test
+    void nullConfigYieldsEmptyMap() {
+        assertThat(ProxyServer.buildShardLabels(null)).isEmpty();
+    }
+
+    @Test
+    void duplicateUrlAcrossShardsKeepsFirstLabel() {
+        // Same URL appearing in both lists should not produce two labels.
+        ShardConfig config = new ShardConfig(1, ShardingMode.BFT_SHARD,
+            List.of(new ShardInfo(7, "http://dup:3000")),
+            List.of(new BftShardInfo("01", "http://dup:3000")));
+
+        Map<String, String> labels = ProxyServer.buildShardLabels(config);
+
+        // App-shard list is processed first, so its label wins.
+        assertThat(labels).containsExactlyInAnyOrderEntriesOf(Map.of(
+            "http://dup:3000", "shard-7"
+        ));
+    }
+}

--- a/src/test/java/org/unicitylabs/proxy/metrics/MetricsHandlerTest.java
+++ b/src/test/java/org/unicitylabs/proxy/metrics/MetricsHandlerTest.java
@@ -1,0 +1,101 @@
+package org.unicitylabs.proxy.metrics;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricsHandlerTest {
+
+    private Server server;
+    private int port;
+    private GatewayMetrics metrics;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        metrics = new GatewayMetrics();
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+        server.setHandler(new MetricsHandler(metrics));
+        server.start();
+        port = connector.getLocalPort();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (server != null) server.stop();
+    }
+
+    @Test
+    void scrapesPrometheusExposition() throws Exception {
+        // Record a few synthetic samples
+        metrics.recordRequest(GatewayMetrics.Outcome.SUCCESS, "submit_commitment", 200, 1_000_000L);
+        metrics.recordRequest(GatewayMetrics.Outcome.UNAUTHORIZED, "submit_commitment", 401, 500_000L);
+        metrics.recordRequest(GatewayMetrics.Outcome.RATE_LIMITED, "submit_commitment", 429, 500_000L);
+        metrics.recordRequest(GatewayMetrics.Outcome.SUCCESS, "wat", 200, 500_000L); // unknown method -> "other"
+        metrics.recordUpstream("http://shard-1", true);
+
+        String body = scrape();
+
+        // Exposition format header
+        assertThat(body).contains("# HELP gateway_requests_total");
+        assertThat(body).contains("# TYPE gateway_requests_total counter");
+
+        // Outcome labels are present
+        assertThat(body).contains("outcome=\"success\"");
+        assertThat(body).contains("outcome=\"unauthorized\"");
+        assertThat(body).contains("outcome=\"rate_limited\"");
+
+        // Method labels: known method preserved, unknown collapsed to "other"
+        assertThat(body).contains("jsonrpc_method=\"submit_commitment\"");
+        assertThat(body).contains("jsonrpc_method=\"other\"");
+
+        // Status class labels
+        assertThat(body).contains("status_class=\"2xx\"");
+        assertThat(body).contains("status_class=\"4xx\"");
+
+        // Latency histogram exposed
+        assertThat(body).contains("gateway_request_duration_seconds");
+
+        // Upstream counter exposed
+        assertThat(body).contains("gateway_upstream_requests_total");
+
+        // JVM binders present
+        assertThat(body).contains("jvm_memory_used_bytes");
+        assertThat(body).contains("jvm_threads_live_threads");
+        assertThat(body).contains("process_uptime_seconds");
+    }
+
+    @Test
+    void unknownPathReturnsNoResponse() throws Exception {
+        // /metrics handler returns false for non-/metrics paths;
+        // with no fallback handler installed, Jetty returns 404.
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        HttpResponse<String> resp = http.send(
+            HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/not-metrics")).build(),
+            HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(404);
+    }
+
+    private String scrape() throws Exception {
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        HttpResponse<String> resp = http.send(
+            HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/metrics")).build(),
+            HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(resp.headers().firstValue("content-type")).isPresent()
+            .get().asString().startsWith("text/plain");
+        return resp.body();
+    }
+}

--- a/src/test/java/org/unicitylabs/proxy/metrics/MetricsHandlerTest.java
+++ b/src/test/java/org/unicitylabs/proxy/metrics/MetricsHandlerTest.java
@@ -88,6 +88,31 @@ public class MetricsHandlerTest {
         assertThat(resp.statusCode()).isEqualTo(404);
     }
 
+    @Test
+    void rejectsNonGetMethodsWith405() throws Exception {
+        HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+        HttpResponse<String> post = http.send(
+            HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/metrics"))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+        assertThat(post.statusCode()).isEqualTo(405);
+        assertThat(post.headers().firstValue("allow")).hasValue("GET");
+    }
+
+    @Test
+    void usesStableShardLabelWhenMapped() throws Exception {
+        metrics.setShardLabels(java.util.Map.of("http://shard-host:1234", "shard-7"));
+        metrics.recordUpstream("http://shard-host:1234", true);
+        metrics.recordUpstream("http://unmapped:9000", true);
+
+        String body = scrape();
+        assertThat(body).contains("shard=\"shard-7\"");
+        assertThat(body).contains("shard=\"unknown\"");
+        // The raw URL must NOT leak as a label value.
+        assertThat(body).doesNotContain("shard=\"http://shard-host:1234\"");
+    }
+
     private String scrape() throws Exception {
         HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
         HttpResponse<String> resp = http.send(

--- a/src/test/java/org/unicitylabs/proxy/metrics/MetricsInstrumentationIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/metrics/MetricsInstrumentationIntegrationTest.java
@@ -1,0 +1,140 @@
+package org.unicitylabs.proxy.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.unicitylabs.proxy.AbstractIntegrationTest;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+import static org.eclipse.jetty.http.HttpStatus.TOO_MANY_REQUESTS_429;
+import static org.eclipse.jetty.http.HttpStatus.UNAUTHORIZED_401;
+
+/**
+ * Wires {@link org.unicitylabs.proxy.RequestHandler} against a full
+ * {@code ProxyServer} + mock upstream and asserts that scraping {@code /metrics}
+ * after each terminal branch (success / unauthorized / rate-limited / routing
+ * error) reports the expected counter increments. Catches regressions in the
+ * callback wrapping or per-branch outcome assignment that the unit-level
+ * {@link MetricsHandlerTest} cannot cover.
+ */
+class MetricsInstrumentationIntegrationTest extends AbstractIntegrationTest {
+
+    @Test
+    void successfulRequestIncrementsSuccessCounter() throws Exception {
+        // Authorized + valid stateId → upstream OK
+        HttpResponse<String> response = performJsonRpcRequest(
+            getAuthorizedRequestBuilder("/"), CERTIFICATION_REQUEST_JSON);
+        assertThat(response.statusCode()).isEqualTo(OK_200);
+
+        String scrape = scrapeMetrics();
+        assertThat(counter(scrape, "gateway_requests_total",
+            "outcome=\"success\"", "jsonrpc_method=\"certification_request\"", "status_class=\"2xx\""))
+            .isGreaterThanOrEqualTo(1);
+        assertThat(counter(scrape, "gateway_upstream_requests_total",
+            "outcome=\"success\""))
+            .isGreaterThanOrEqualTo(1);
+        // Latency timer also recorded
+        assertThat(counter(scrape, "gateway_request_duration_seconds_count",
+            "outcome=\"success\"", "jsonrpc_method=\"certification_request\""))
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void unauthorizedRequestIncrementsUnauthorizedCounter() throws Exception {
+        // No Authorization header → 401 on a protected method
+        HttpResponse<String> response = performJsonRpcRequest(
+            getNotAuthorizedRequestBuilder("/"), CERTIFICATION_REQUEST_JSON);
+        assertThat(response.statusCode()).isEqualTo(UNAUTHORIZED_401);
+
+        String scrape = scrapeMetrics();
+        assertThat(counter(scrape, "gateway_requests_total",
+            "outcome=\"unauthorized\"", "jsonrpc_method=\"certification_request\"", "status_class=\"4xx\""))
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void rateLimitedRequestIncrementsRateLimitedCounter() throws Exception {
+        // Standard plan = 10 req/s (see PLAN_STANDARD); fire 12 to guarantee a 429
+        int over = 12;
+        boolean got429 = false;
+        for (int i = 0; i < over; i++) {
+            HttpResponse<String> response = performJsonRpcRequest(
+                getAuthorizedRequestBuilder("/"), CERTIFICATION_REQUEST_JSON);
+            if (response.statusCode() == TOO_MANY_REQUESTS_429) {
+                got429 = true;
+            }
+        }
+        assertThat(got429).as("expected at least one 429 within %d requests", over).isTrue();
+
+        String scrape = scrapeMetrics();
+        assertThat(counter(scrape, "gateway_requests_total",
+            "outcome=\"rate_limited\"", "jsonrpc_method=\"certification_request\"", "status_class=\"4xx\""))
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void routingErrorIncrementsRoutingErrorCounter() throws Exception {
+        // get_inclusion_proof.v2 with a stateId of all zeros — valid hex but
+        // causes the router to fail because no shard prefix matches in the
+        // single-shard test config. Either way it's parsed as JSON-RPC and
+        // hits a 4xx path that's not unauthorized/rate-limited.
+        HttpResponse<String> response = performJsonRpcRequest(
+            getAuthorizedRequestBuilder("/"), GET_INCLUSION_PROOF_V2_JSON);
+        // Status may be 2xx (forwarded successfully) or 4xx routing_error
+        // depending on shard config — what we're verifying is that
+        // *some* counter increments and the request was instrumented.
+        assertThat(response.statusCode()).isBetween(200, 599);
+
+        String scrape = scrapeMetrics();
+        // get_inclusion_proof.v2 is in the known-methods set
+        long total = counter(scrape, "gateway_requests_total",
+            "jsonrpc_method=\"get_inclusion_proof.v2\"");
+        assertThat(total).as("expected at least one request counted for get_inclusion_proof.v2").isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void successCounterIncrementsRateLimitRemainingHeaderPresent() throws Exception {
+        // Sanity check that instrumentation does not break the existing
+        // X-RateLimit-Remaining header path.
+        HttpResponse<String> response = performJsonRpcRequest(
+            getAuthorizedRequestBuilder("/"), CERTIFICATION_REQUEST_JSON);
+        assertThat(response.statusCode()).isEqualTo(OK_200);
+        assertThat(response.headers().firstValue("X-RateLimit-Remaining"))
+            .isPresent();
+    }
+
+    private String scrapeMetrics() throws Exception {
+        HttpRequest req = HttpRequest.newBuilder(java.net.URI.create(getProxyUrl() + "/metrics")).GET().build();
+        HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(200);
+        return resp.body();
+    }
+
+    /**
+     * Sums all values of {@code metric{... matchers all present ...}} samples
+     * in a Prometheus text-format scrape. Returns 0 if no sample matches.
+     */
+    private static long counter(String scrape, String metric, String... mustContain) {
+        Pattern line = Pattern.compile("^" + Pattern.quote(metric) + "(?:\\{([^}]*)\\})?\\s+([0-9eE.+-]+)\\s*$",
+            Pattern.MULTILINE);
+        Matcher m = line.matcher(scrape);
+        long sum = 0;
+        while (m.find()) {
+            String labels = m.group(1) == null ? "" : m.group(1);
+            boolean ok = true;
+            for (String needle : mustContain) {
+                if (!labels.contains(needle)) { ok = false; break; }
+            }
+            if (ok) {
+                try {
+                    sum += (long) Double.parseDouble(m.group(2));
+                } catch (NumberFormatException ignored) { /* skip */ }
+            }
+        }
+        return sum;
+    }
+}

--- a/src/test/java/org/unicitylabs/proxy/metrics/MetricsInstrumentationIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/metrics/MetricsInstrumentationIntegrationTest.java
@@ -146,6 +146,21 @@ class MetricsInstrumentationIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    void rateLimitBucketGaugeReflectsAuthorizedTraffic() throws Exception {
+        // Before any authorized request, no bucket has been allocated.
+        long before = gauge(scrapeMetrics(), "gateway_ratelimit_buckets");
+
+        // One authorized request → bucket created for the default test API key.
+        HttpResponse<String> response = performJsonRpcRequest(
+            getAuthorizedRequestBuilder("/"), CERTIFICATION_REQUEST_JSON);
+        assertThat(response.statusCode()).isEqualTo(OK_200);
+
+        long after = gauge(scrapeMetrics(), "gateway_ratelimit_buckets");
+        assertThat(after).as("gateway_ratelimit_buckets should grow after a new key allocates a bucket")
+            .isGreaterThan(before);
+    }
+
+    @Test
     void successCounterIncrementsRateLimitRemainingHeaderPresent() throws Exception {
         // Sanity check that instrumentation does not break the existing
         // X-RateLimit-Remaining header path.
@@ -161,6 +176,24 @@ class MetricsInstrumentationIntegrationTest extends AbstractIntegrationTest {
         HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
         assertThat(resp.statusCode()).isEqualTo(200);
         return resp.body();
+    }
+
+    /**
+     * Returns the (single) value of an unlabeled gauge. Returns -1 if absent
+     * so the caller can distinguish "not present" from "present and zero".
+     */
+    private static long gauge(String scrape, String metric) {
+        Pattern line = Pattern.compile("^" + Pattern.quote(metric) + "(?:\\{[^}]*\\})?\\s+([0-9eE.+-]+)\\s*$",
+            Pattern.MULTILINE);
+        Matcher m = line.matcher(scrape);
+        if (m.find()) {
+            try {
+                return (long) Double.parseDouble(m.group(1));
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/src/test/java/org/unicitylabs/proxy/metrics/MetricsInstrumentationIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/metrics/MetricsInstrumentationIntegrationTest.java
@@ -5,10 +5,13 @@ import org.unicitylabs.proxy.AbstractIntegrationTest;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jetty.http.HttpStatus.BAD_GATEWAY_502;
+import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.eclipse.jetty.http.HttpStatus.TOO_MANY_REQUESTS_429;
 import static org.eclipse.jetty.http.HttpStatus.UNAUTHORIZED_401;
@@ -78,22 +81,68 @@ class MetricsInstrumentationIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     void routingErrorIncrementsRoutingErrorCounter() throws Exception {
-        // get_inclusion_proof.v2 with a stateId of all zeros — valid hex but
-        // causes the router to fail because no shard prefix matches in the
-        // single-shard test config. Either way it's parsed as JSON-RPC and
-        // hits a 4xx path that's not unauthorized/rate-limited.
+        // get_inclusion_proof.v2 is shard-bound and requires stateId. Sending
+        // it with empty params triggers the routing-error branch in
+        // determineTargetUrl deterministically (no body parsing needed).
+        String body = """
+            {"jsonrpc":"2.0","method":"get_inclusion_proof.v2","params":{},"id":1}""";
         HttpResponse<String> response = performJsonRpcRequest(
-            getAuthorizedRequestBuilder("/"), GET_INCLUSION_PROOF_V2_JSON);
-        // Status may be 2xx (forwarded successfully) or 4xx routing_error
-        // depending on shard config — what we're verifying is that
-        // *some* counter increments and the request was instrumented.
-        assertThat(response.statusCode()).isBetween(200, 599);
+            getNotAuthorizedRequestBuilder("/"), body);
+        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST_400);
 
         String scrape = scrapeMetrics();
-        // get_inclusion_proof.v2 is in the known-methods set
-        long total = counter(scrape, "gateway_requests_total",
-            "jsonrpc_method=\"get_inclusion_proof.v2\"");
-        assertThat(total).as("expected at least one request counted for get_inclusion_proof.v2").isGreaterThanOrEqualTo(1);
+        long routingErrors = counter(scrape, "gateway_requests_total",
+            "outcome=\"routing_error\"",
+            "jsonrpc_method=\"get_inclusion_proof.v2\"",
+            "status_class=\"4xx\"");
+        assertThat(routingErrors).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void oversizedHeadersIncrementBadRequestCounter() throws Exception {
+        // Send >MAX_HEADER_COUNT (200) headers; validateRequestSizeLimits
+        // returns the bad_request branch.
+        HttpRequest.Builder b = getAuthorizedRequestBuilder("/");
+        for (int i = 0; i < 250; i++) {
+            b = b.header("X-Stuff-" + i, "v" + i);
+        }
+        HttpRequest req = b
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(CERTIFICATION_REQUEST_JSON))
+            .timeout(Duration.ofSeconds(5))
+            .build();
+        HttpResponse<String> response = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(BAD_REQUEST_400);
+
+        String scrape = scrapeMetrics();
+        long badRequests = counter(scrape, "gateway_requests_total",
+            "outcome=\"bad_request\"",
+            "jsonrpc_method=\"certification_request\"",
+            "status_class=\"4xx\"");
+        assertThat(badRequests).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void unreachableUpstreamIncrementsUpstreamErrorCounter() throws Exception {
+        // Stop the mock so the proxy's upstream call fails with a connection
+        // error → handleError → outcome=upstream_error.
+        mockServer.stop();
+
+        HttpResponse<String> response = performJsonRpcRequest(
+            getAuthorizedRequestBuilder("/"), CERTIFICATION_REQUEST_JSON);
+        assertThat(response.statusCode()).isEqualTo(BAD_GATEWAY_502);
+
+        String scrape = scrapeMetrics();
+        long upstreamErrors = counter(scrape, "gateway_requests_total",
+            "outcome=\"upstream_error\"",
+            "jsonrpc_method=\"certification_request\"",
+            "status_class=\"5xx\"");
+        assertThat(upstreamErrors).isGreaterThanOrEqualTo(1);
+
+        // The dedicated upstream counter should also reflect the failure.
+        long upstreamFailures = counter(scrape, "gateway_upstream_requests_total",
+            "outcome=\"error\"");
+        assertThat(upstreamFailures).isGreaterThanOrEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds Micrometer + Prometheus registry with JVM/system binders so the gateway can be scraped alongside the aggregator and BFT services.
- Wires `GET /metrics` (text/plain v0.0.4) into the existing Jetty handler chain.
- Instruments `RequestHandler` to record outcome at every terminal branch (auth fail, rate-limit, size validation, routing error, upstream error, success); the response callback is wrapped once at entry and records exactly once on completion.

## Metrics exposed
- `gateway_requests_total{outcome,jsonrpc_method,status_class}` — driver for successful and rejected/throttled req/s
- `gateway_request_duration_seconds` (histogram) — end-to-end latency including upstream
- `gateway_upstream_requests_total{shard,outcome}`
- `gateway_ratelimit_buckets` (gauge) — active per-key rate-limit buckets
- JVM via Micrometer binders: `jvm_memory_used_bytes`, `jvm_gc_pause_seconds`, `jvm_threads_live`, `process_cpu_usage`, `system_cpu_usage`, `process_uptime_seconds`, `process_files_open_files`

`jsonrpc_method` is capped to a known aggregator method set; anything else collapses to `other` so label cardinality stays bounded. No labels for API key or client IP.

## Useful Prometheus queries
- successful req/s — `rate(gateway_requests_total{outcome="success"}[1m])`
- rejected/throttled — `rate(gateway_requests_total{outcome=~"unauthorized|rate_limited"}[1m])`
- per-endpoint — `sum by (jsonrpc_method) (rate(gateway_requests_total[1m]))`
- heap — `jvm_memory_used_bytes{area="heap"}`
- CPU — `process_cpu_usage`

Closes #31.

Base note: PR is targeted at `bft-sharding-routing` because that branch is itself an open unmerged PR (#27); rebase onto `main` once #27 lands.

## Test plan
- [x] `./gradlew test` — full unit suite green
- [x] `./gradlew build` — fat-jar builds
- [x] New `MetricsHandlerTest` verifies exposition format, `outcome` / `jsonrpc_method` / `status_class` label dimensions, latency histogram presence, JVM metrics presence
- [ ] Manual smoke: scrape `http://localhost:8080/metrics` against a running gateway, verify counters move under load