### PR TITLE
Add h2c gateway proxying and upstream metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,24 @@ Here are the key URLs:
 - Admin UI: http://localhost:8080/admin.
 - Incoming requests are proxied from here: http://localhost:8080/.
 
+#### HTTP/2 and HAProxy
+
+Protocol handling is per hop. `--enable-h2c` enables cleartext HTTP/2 for clients connecting to the proxy while still accepting HTTP/1. `--upstream-h2c` makes the proxy use cleartext HTTP/2 when forwarding to `http://` shard URLs.
+
+When HAProxy is in front of a shard, keep the frontend HTTP/1-compatible and enable HTTP/2 on the backend server line:
+
+```haproxy
+frontend shard_frontend
+    bind *:3000
+    default_backend shard_backend
+
+backend shard_backend
+    http-reuse always
+    server shard-leader aggregator-shard:3000 proto h2
+```
+
+With this setup direct HTTP/1 clients can still call HAProxy, while proxy -> HAProxy can use h2c and HAProxy -> aggregator uses HTTP/2.
+
 #### Architecture
 
 - **Proxy**: Single proxy instance exposed on port 8080 (configurable via `PROXY_PORT`)

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ repositories {
 dependencies {
     implementation 'org.eclipse.jetty:jetty-server:12.1.4'
     implementation 'org.eclipse.jetty:jetty-client:12.1.4'
+    implementation 'org.eclipse.jetty.http2:jetty-http2-server:12.1.4'
+    implementation 'org.eclipse.jetty.http2:jetty-http2-client:12.1.4'
+    implementation 'org.eclipse.jetty.http2:jetty-http2-client-transport:12.1.4'
     implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.4'
     implementation 'org.eclipse.jetty.ee10:jetty-ee10-proxy:12.1.4'
 

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -6,7 +6,7 @@ x-proxy-service: &proxy-service
     network: host
   environment:
     # Proxy configuration - container always listens on 8080 internally
-    PROXY_ARGS: "--port 8080 "
+    PROXY_ARGS: "--port 8080 --worker-threads ${GATEWAY_WORKER_THREADS:-64} "
     # Admin dashboard configuration
     ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     # Server secret for API operations (must be hex string with even length)
@@ -33,6 +33,10 @@ x-proxy-service: &proxy-service
   depends_on:
     postgres:
       condition: service_healthy
+  ulimits:
+    nofile:
+      soft: 1048576
+      hard: 1048576
   healthcheck:
     test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1"]
     interval: 10s
@@ -77,6 +81,10 @@ services:
       - "${PROXY_PORT:-8080}:8080"
       # Stats/monitoring page
       - "${HAPROXY_STATS_PORT:-8404}:8404"
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     container_name: aggregator-proxy
     environment:
       # Proxy configuration - container always listens on 8080 internally
-      PROXY_ARGS: "--port 8080 --protected-methods ${PROTECTED_METHODS:-certification_request} --token-type-ids-url file:///etc/aggregator/test-token-types.json"
+      PROXY_ARGS: "--port 8080 --enable-h2c --upstream-h2c --worker-threads ${GATEWAY_WORKER_THREADS:-64} --protected-methods ${PROTECTED_METHODS:-certification_request} --token-type-ids-url file:///etc/aggregator/test-token-types.json"
       # Shard configuration
       SHARD_CONFIG_URI: "file:///etc/aggregator/shard-config.json"
       # Admin dashboard configuration
@@ -41,6 +41,10 @@ services:
     ports:
       # Map host port (configurable) to container port 8080 (fixed)
       - "${PROXY_PORT:-8080}:8080"
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/main/java/org/unicitylabs/proxy/ProxyConfig.java
+++ b/src/main/java/org/unicitylabs/proxy/ProxyConfig.java
@@ -26,6 +26,27 @@ public class ProxyConfig {
     @Parameter(names = {"--idle-timeout"}, description = "Idle timeout in milliseconds")
     private int idleTimeout = 3000;
 
+    @Parameter(names = {"--enable-h2c"}, description = "Enable cleartext HTTP/2 on the inbound listener")
+    private boolean h2cEnabled = false;
+
+    @Parameter(names = {"--upstream-h2c"}, description = "Use cleartext HTTP/2 when proxying to http:// upstream aggregators")
+    private boolean upstreamH2cEnabled = false;
+
+    @Parameter(names = {"--upstream-h2c-max-connections-per-destination"}, description = "Maximum upstream h2c connections per destination")
+    private int upstreamH2cMaxConnectionsPerDestination = 32;
+
+    @Parameter(names = {"--upstream-h2c-max-queued-requests-per-destination"}, description = "Maximum upstream h2c queued requests per destination")
+    private int upstreamH2cMaxQueuedRequestsPerDestination = 100000;
+
+    @Parameter(names = {"--upstream-h2c-initial-session-recv-window"}, description = "Initial upstream h2c session receive window in bytes")
+    private int upstreamH2cInitialSessionRecvWindow = 64 * 1024 * 1024;
+
+    @Parameter(names = {"--upstream-h2c-initial-stream-recv-window"}, description = "Initial upstream h2c stream receive window in bytes")
+    private int upstreamH2cInitialStreamRecvWindow = 16 * 1024 * 1024;
+
+    @Parameter(names = {"--upstream-h2c-max-local-streams"}, description = "Maximum upstream h2c local streams")
+    private int upstreamH2cMaxLocalStreams = 10000;
+
     @Parameter(names = {"--admin-password"}, description = "Admin dashboard password")
     private String adminPassword = null;
 
@@ -82,6 +103,34 @@ public class ProxyConfig {
         return idleTimeout;
     }
 
+    public boolean isH2cEnabled() {
+        return h2cEnabled;
+    }
+
+    public boolean isUpstreamH2cEnabled() {
+        return upstreamH2cEnabled;
+    }
+
+    public int getUpstreamH2cMaxConnectionsPerDestination() {
+        return upstreamH2cMaxConnectionsPerDestination;
+    }
+
+    public int getUpstreamH2cMaxQueuedRequestsPerDestination() {
+        return upstreamH2cMaxQueuedRequestsPerDestination;
+    }
+
+    public int getUpstreamH2cInitialSessionRecvWindow() {
+        return upstreamH2cInitialSessionRecvWindow;
+    }
+
+    public int getUpstreamH2cInitialStreamRecvWindow() {
+        return upstreamH2cInitialStreamRecvWindow;
+    }
+
+    public int getUpstreamH2cMaxLocalStreams() {
+        return upstreamH2cMaxLocalStreams;
+    }
+
     public String getAdminPassword() {
         // Check environment variable first, then command line parameter
         String envPassword = environmentProvider.getEnv(ADMIN_PASSWORD);
@@ -130,13 +179,27 @@ public class ProxyConfig {
         this.tokenTypeName = tokenTypeName;
     }
 
+    void setUpstreamH2cEnabled(boolean upstreamH2cEnabled) {
+        this.upstreamH2cEnabled = upstreamH2cEnabled;
+    }
+
+    void setUpstreamH2cMaxConnectionsPerDestination(int upstreamH2cMaxConnectionsPerDestination) {
+        this.upstreamH2cMaxConnectionsPerDestination = upstreamH2cMaxConnectionsPerDestination;
+    }
+
+    void setUpstreamH2cMaxQueuedRequestsPerDestination(int upstreamH2cMaxQueuedRequestsPerDestination) {
+        this.upstreamH2cMaxQueuedRequestsPerDestination = upstreamH2cMaxQueuedRequestsPerDestination;
+    }
+
     @Override
     public String toString() {
         return String.format(
             "ProxyConfig{port=%d, workerThreads=%d, " +
-            "connectTimeout=%d, readTimeout=%d, idleTimeout=%d, protectedMethods='%s'}",
+            "connectTimeout=%d, readTimeout=%d, idleTimeout=%d, h2cEnabled=%s, upstreamH2cEnabled=%s, " +
+            "upstreamH2cMaxConnectionsPerDestination=%d, upstreamH2cMaxQueuedRequestsPerDestination=%d, protectedMethods='%s'}",
             port, workerThreads,
-            connectTimeout, readTimeout, idleTimeout, protectedMethods
+            connectTimeout, readTimeout, idleTimeout, h2cEnabled, upstreamH2cEnabled,
+            upstreamH2cMaxConnectionsPerDestination, upstreamH2cMaxQueuedRequestsPerDestination, protectedMethods
         );
     }
 }

--- a/src/main/java/org/unicitylabs/proxy/ProxyServer.java
+++ b/src/main/java/org/unicitylabs/proxy/ProxyServer.java
@@ -1,6 +1,7 @@
 package org.unicitylabs.proxy;
 
 import org.eclipse.jetty.server.*;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
@@ -247,7 +248,14 @@ public class ProxyServer {
 
         HttpConnectionFactory httpFactory = new HttpConnectionFactory(httpConfig);
 
-        ServerConnector connector = new ServerConnector(server, httpFactory);
+        ServerConnector connector;
+        if (config.isH2cEnabled()) {
+            HTTP2CServerConnectionFactory h2cFactory = new HTTP2CServerConnectionFactory(httpConfig);
+            connector = new ServerConnector(server, httpFactory, h2cFactory);
+            logger.info("Inbound h2c enabled on proxy listener");
+        } else {
+            connector = new ServerConnector(server, httpFactory);
+        }
         connector.setPort(config.getPort());
         connector.setHost("0.0.0.0");
         connector.setIdleTimeout(config.getIdleTimeout());
@@ -274,11 +282,15 @@ public class ProxyServer {
             Thread.currentThread().interrupt();
         }
 
-        server.stop();
-        // Release the meter registry's listeners (notably JvmGcMetrics' GC
-        // notification listener) — required when the same JVM constructs
-        // and tears down ProxyServer repeatedly.
-        metrics.close();
+        try {
+            server.stop();
+        } finally {
+            requestHandler.stopUpstreamH2cClient();
+            // Release the meter registry's listeners (notably JvmGcMetrics' GC
+            // notification listener) — required when the same JVM constructs
+            // and tears down ProxyServer repeatedly.
+            metrics.close();
+        }
         logger.info("Proxy server stopped");
     }
     

--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.Set;
 import java.util.Arrays;
 import java.util.Locale;
@@ -39,6 +40,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.jetty.client.BufferingResponseListener;
+import org.eclipse.jetty.client.BytesRequestContent;
+import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
 import org.unicitylabs.proxy.util.CorsUtils;
 import org.unicitylabs.sdk.serializer.cbor.CborDeserializer;
 import org.unicitylabs.sdk.util.HexConverter;
@@ -95,9 +102,11 @@ public class RequestHandler extends Handler.Abstract {
     static final String HEADER_X_STATE_ID = "X-State-ID";
 
     private final HttpClient httpClient;
+    private final org.eclipse.jetty.client.HttpClient upstreamH2cClient;
     private volatile ShardRouter shardRouter;
     private final Duration readTimeout;
     private final boolean useVirtualThreads;
+    private final boolean upstreamH2cEnabled;
     private final CachedApiKeyManager apiKeyManager;
     private final RateLimiterManager rateLimiterManager;
     private final WebUIHandler webUIHandler;
@@ -120,6 +129,7 @@ public class RequestHandler extends Handler.Abstract {
         this.shardRouter = shardRouter;
         this.readTimeout = Duration.ofMillis(config.getReadTimeout());
         this.useVirtualThreads = config.isVirtualThreads();
+        this.upstreamH2cEnabled = config.isUpstreamH2cEnabled();
         this.apiKeyManager = CachedApiKeyManager.getInstance();
         this.rateLimiterManager = new RateLimiterManager(apiKeyManager);
         this.webUIHandler = new WebUIHandler(databaseConfig);
@@ -143,8 +153,40 @@ public class RequestHandler extends Handler.Abstract {
         }
         
         this.httpClient = httpClientBuilder.build();
+        this.upstreamH2cClient = upstreamH2cEnabled ? buildUpstreamH2cClient(config) : null;
+        if (upstreamH2cEnabled) {
+            logger.info(
+                "Using Jetty h2c client for http:// upstream aggregators (maxConnectionsPerDestination={}, maxQueuedRequestsPerDestination={})",
+                upstreamH2cClient.getMaxConnectionsPerDestination(),
+                upstreamH2cClient.getMaxRequestsQueuedPerDestination()
+            );
+        }
 
         logger.info("Request handler initialized with {} shard targets", shardRouter.getAllTargets().size());
+    }
+
+    private org.eclipse.jetty.client.HttpClient buildUpstreamH2cClient(ProxyConfig config) {
+        HTTP2Client http2Client = new HTTP2Client();
+        http2Client.setUseALPN(false);
+        http2Client.setConnectTimeout(config.getConnectTimeout());
+        http2Client.setIdleTimeout(config.getIdleTimeout());
+        http2Client.setStreamIdleTimeout(config.getReadTimeout());
+        http2Client.setInitialSessionRecvWindow(config.getUpstreamH2cInitialSessionRecvWindow());
+        http2Client.setInitialStreamRecvWindow(config.getUpstreamH2cInitialStreamRecvWindow());
+        http2Client.setMaxLocalStreams(config.getUpstreamH2cMaxLocalStreams());
+
+        org.eclipse.jetty.client.HttpClient client = new org.eclipse.jetty.client.HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+        client.setConnectTimeout(config.getConnectTimeout());
+        client.setIdleTimeout(config.getIdleTimeout());
+        client.setFollowRedirects(false);
+        client.setMaxConnectionsPerDestination(config.getUpstreamH2cMaxConnectionsPerDestination());
+        client.setMaxRequestsQueuedPerDestination(config.getUpstreamH2cMaxQueuedRequestsPerDestination());
+        try {
+            client.start();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to start upstream h2c client", e);
+        }
+        return client;
     }
     
     @Override
@@ -334,6 +376,11 @@ public class RequestHandler extends Handler.Abstract {
                     logger.debug("Request header: {}: {}", field.getName(), field.getValue()));
             }
 
+            if (shouldUseUpstreamH2c(targetUri)) {
+                proxyRequestWithUpstreamH2c(request, cachedBody, method, targetUrl, targetUri, jsonRpcMethod, response, callback, recorder);
+                return;
+            }
+
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(URI.create(targetUri))
                 .timeout(readTimeout);
@@ -341,25 +388,101 @@ public class RequestHandler extends Handler.Abstract {
             forwardBody(cachedBody, method, requestBuilder);
             HttpRequest httpRequest = requestBuilder.build();
 
-            httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
-                .whenComplete((httpResponse, throwable) -> {
-                    if (throwable != null) {
-                        logger.error("Failed to proxy request to {}: {}", targetUri, throwable.getMessage());
-                        metrics.recordUpstream(targetUrl, false);
-                        recorder.setOutcome(Outcome.UPSTREAM_ERROR);
-                        handleError(response, callback, throwable);
-                    } else {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Received response from {}: status {}", targetUri, httpResponse.statusCode());
+            long upstreamStartNanos = System.nanoTime();
+            metrics.incrementActiveUpstreamRequests();
+            try {
+                httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofByteArray())
+                    .whenComplete((httpResponse, throwable) -> {
+                        long upstreamElapsedNanos = System.nanoTime() - upstreamStartNanos;
+                        metrics.decrementActiveUpstreamRequests();
+                        if (throwable != null) {
+                            logger.error("Failed to proxy request to {}: {}", targetUri, throwable.getMessage());
+                            metrics.recordUpstream(targetUrl, false);
+                            metrics.recordUpstreamDuration(targetUrl, jsonRpcMethod, false, upstreamElapsedNanos);
+                            recorder.setOutcome(Outcome.UPSTREAM_ERROR);
+                            handleError(response, callback, throwable);
+                        } else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Received response from {}: status {}", targetUri, httpResponse.statusCode());
+                            }
+                            boolean upstreamSuccess = httpResponse.statusCode() < 500;
+                            metrics.recordUpstream(targetUrl, upstreamSuccess);
+                            metrics.recordUpstreamDuration(targetUrl, jsonRpcMethod, upstreamSuccess, upstreamElapsedNanos);
+                            forwardResponse(response, callback, httpResponse);
                         }
-                        metrics.recordUpstream(targetUrl, httpResponse.statusCode() < 500);
-                        forwardResponse(response, callback, httpResponse);
-                    }
-                });
+                    });
+            } catch (Exception e) {
+                metrics.decrementActiveUpstreamRequests();
+                metrics.recordUpstream(targetUrl, false);
+                metrics.recordUpstreamDuration(targetUrl, jsonRpcMethod, false, System.nanoTime() - upstreamStartNanos);
+                throw e;
+            }
 
         } catch (Exception e) {
             recorder.setOutcome(Outcome.UPSTREAM_ERROR);
             handleError(response, callback, e);
+        }
+    }
+
+    private boolean shouldUseUpstreamH2c(String targetUri) {
+        return upstreamH2cEnabled
+            && upstreamH2cClient != null
+            && targetUri.regionMatches(true, 0, "http://", 0, "http://".length());
+    }
+
+    private void proxyRequestWithUpstreamH2c(
+        Request request,
+        byte[] cachedBody,
+        String method,
+        String targetUrl,
+        String targetUri,
+        String jsonRpcMethod,
+        Response response,
+        Callback callback,
+        RequestMetricsRecorder recorder
+    ) {
+        org.eclipse.jetty.client.Request upstreamRequest = upstreamH2cClient.newRequest(URI.create(targetUri))
+            .method(method)
+            .version(HttpVersion.HTTP_2)
+            .timeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .idleTimeout(readTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .followRedirects(false);
+        forwardAllNonRestrictedHeaders(request, upstreamRequest);
+        forwardBody(cachedBody, method, upstreamRequest);
+
+        long upstreamStartNanos = System.nanoTime();
+        metrics.incrementActiveUpstreamRequests();
+        try {
+            upstreamRequest.send(new BufferingResponseListener(MAX_PAYLOAD_SIZE_BYTES) {
+                @Override
+                public void onComplete(Result result) {
+                    long upstreamElapsedNanos = System.nanoTime() - upstreamStartNanos;
+                    metrics.decrementActiveUpstreamRequests();
+                    if (result.isFailed()) {
+                        Throwable failure = result.getFailure();
+                        logger.error("Failed to proxy h2c request to {}: {}", targetUri, failure.getMessage());
+                        metrics.recordUpstream(targetUrl, false);
+                        metrics.recordUpstreamDuration(targetUrl, jsonRpcMethod, false, upstreamElapsedNanos);
+                        recorder.setOutcome(Outcome.UPSTREAM_ERROR);
+                        handleError(response, callback, failure);
+                        return;
+                    }
+
+                    org.eclipse.jetty.client.Response upstreamResponse = result.getResponse();
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Received h2c response from {}: status {}", targetUri, upstreamResponse.getStatus());
+                    }
+                    boolean upstreamSuccess = upstreamResponse.getStatus() < 500;
+                    metrics.recordUpstream(targetUrl, upstreamSuccess);
+                    metrics.recordUpstreamDuration(targetUrl, jsonRpcMethod, upstreamSuccess, upstreamElapsedNanos);
+                    forwardResponse(response, callback, upstreamResponse, getContent());
+                }
+            });
+        } catch (Exception e) {
+            metrics.decrementActiveUpstreamRequests();
+            metrics.recordUpstream(targetUrl, false);
+            metrics.recordUpstreamDuration(targetUrl, jsonRpcMethod, false, System.nanoTime() - upstreamStartNanos);
+            throw e;
         }
     }
 
@@ -385,6 +508,19 @@ public class RequestHandler extends Handler.Abstract {
         }
     }
 
+    private void forwardBody(byte[] requestBody, String method, org.eclipse.jetty.client.Request requestBuilder) {
+        if (requestBody != null) {
+            if (logger.isTraceEnabled()) {
+                String bodyStr = new String(requestBody, 0, Math.min(requestBody.length, 1000));
+                logger.trace("Request body (first 1000 chars): {}", bodyStr);
+            }
+
+            requestBuilder.body(new BytesRequestContent(requestBody));
+        } else if (requiresRequestBody(method)) {
+            requestBuilder.body(new BytesRequestContent(new byte[0]));
+        }
+    }
+
     private void forwardAllNonRestrictedHeaders(Request request, HttpRequest.Builder requestBuilder) {
         Set<String> connectionTokens = parseConnectionTokens(request.getHeaders().getField(CONNECTION.asString()));
         request.getHeaders().forEach(field -> {
@@ -392,6 +528,18 @@ public class RequestHandler extends Handler.Abstract {
             if (!isRestrictedHeader(name) && !connectionTokens.contains(name.toLowerCase(Locale.ROOT))) {
                 requestBuilder.header(name, field.getValue());
             }
+        });
+    }
+
+    private void forwardAllNonRestrictedHeaders(Request request, org.eclipse.jetty.client.Request requestBuilder) {
+        Set<String> connectionTokens = parseConnectionTokens(request.getHeaders().getField(CONNECTION.asString()));
+        requestBuilder.headers(headers -> {
+            request.getHeaders().forEach(field -> {
+                String name = field.getName();
+                if (!isRestrictedHeader(name) && !connectionTokens.contains(name.toLowerCase(Locale.ROOT))) {
+                    headers.add(name, field.getValue());
+                }
+            });
         });
     }
 
@@ -425,6 +573,40 @@ public class RequestHandler extends Handler.Abstract {
             logger.error("Error forwarding response", e);
             handleError(response, callback, e);
         }
+    }
+
+    private void forwardResponse(Response response, Callback callback, org.eclipse.jetty.client.Response upstreamResponse, byte[] body) {
+        try {
+            response.setStatus(upstreamResponse.getStatus());
+
+            for (var field : upstreamResponse.getHeaders()) {
+                String name = field.getName();
+                if (!name.equalsIgnoreCase(CONNECTION.asString()) &&
+                    !name.equalsIgnoreCase(TRANSFER_ENCODING.asString()) &&
+                    !CorsUtils.isCorsHeader(name)) {
+                    response.getHeaders().add(name, field.getValue());
+                }
+            }
+
+            if (body.length > 0) {
+                response.write(true, ByteBuffer.wrap(body), callback);
+            } else {
+                callback.succeeded();
+            }
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("H2C response forwarded: {} {}", upstreamResponse.getStatus(), upstreamResponse.getRequest().getURI());
+            }
+        } catch (Exception e) {
+            logger.error("Error forwarding h2c response", e);
+            handleError(response, callback, e);
+        }
+    }
+
+    private boolean requiresRequestBody(String method) {
+        return POST.asString().equals(method)
+            || PUT.asString().equals(method)
+            || "PATCH".equalsIgnoreCase(method);
     }
 
     private void handleError(Response response, Callback callback, Throwable throwable) {
@@ -464,6 +646,17 @@ public class RequestHandler extends Handler.Abstract {
     
     public RateLimiterManager getRateLimiterManager() {
         return rateLimiterManager;
+    }
+
+    public void stopUpstreamH2cClient() {
+        if (upstreamH2cClient == null) {
+            return;
+        }
+        try {
+            upstreamH2cClient.stop();
+        } catch (Exception e) {
+            logger.warn("Failed to stop upstream h2c client", e);
+        }
     }
 
     public CachedApiKeyManager getApiKeyManager() {
@@ -713,6 +906,7 @@ public class RequestHandler extends Handler.Abstract {
         RequestMetricsRecorder(GatewayMetrics metrics, Response response) {
             this.metrics = metrics;
             this.response = response;
+            this.metrics.incrementActiveRequests();
         }
 
         void setJsonRpcMethod(String method) { this.jsonRpcMethod = method; }
@@ -737,7 +931,11 @@ public class RequestHandler extends Handler.Abstract {
         private void recordOnce() {
             if (recorded.compareAndSet(false, true)) {
                 long elapsed = System.nanoTime() - startNanos;
-                metrics.recordRequest(outcome, jsonRpcMethod, response.getStatus(), elapsed);
+                try {
+                    metrics.recordRequest(outcome, jsonRpcMethod, response.getStatus(), elapsed);
+                } finally {
+                    metrics.decrementActiveRequests();
+                }
             }
         }
     }

--- a/src/main/java/org/unicitylabs/proxy/RequestHandler.java
+++ b/src/main/java/org/unicitylabs/proxy/RequestHandler.java
@@ -516,8 +516,6 @@ public class RequestHandler extends Handler.Abstract {
             }
 
             requestBuilder.body(new BytesRequestContent(requestBody));
-        } else if (requiresRequestBody(method)) {
-            requestBuilder.body(new BytesRequestContent(new byte[0]));
         }
     }
 
@@ -603,12 +601,6 @@ public class RequestHandler extends Handler.Abstract {
         }
     }
 
-    private boolean requiresRequestBody(String method) {
-        return POST.asString().equals(method)
-            || PUT.asString().equals(method)
-            || "PATCH".equalsIgnoreCase(method);
-    }
-
     private void handleError(Response response, Callback callback, Throwable throwable) {
         logger.error("Error processing request", throwable);
         
@@ -623,8 +615,8 @@ public class RequestHandler extends Handler.Abstract {
     }
     
     private boolean hasBody(String method) {
-        return POST.asString().equals(method) || PUT.asString().equals(method) ||
-               PATCH.asString().equals(method) || DELETE.asString().equals(method);
+        return POST.asString().equalsIgnoreCase(method) || PUT.asString().equalsIgnoreCase(method) ||
+               PATCH.asString().equalsIgnoreCase(method) || DELETE.asString().equalsIgnoreCase(method);
     }
 
     private boolean isRestrictedHeader(String name) {

--- a/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
+++ b/src/main/java/org/unicitylabs/proxy/metrics/GatewayMetrics.java
@@ -1,6 +1,7 @@
 package org.unicitylabs.proxy.metrics;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.ToDoubleFunction;
 
 /**
@@ -54,6 +56,9 @@ public final class GatewayMetrics implements AutoCloseable {
     static final String REQUESTS_METRIC = "gateway_requests_total";
     static final String DURATION_METRIC = "gateway_request_duration_seconds";
     static final String UPSTREAM_METRIC = "gateway_upstream_requests_total";
+    static final String UPSTREAM_DURATION_METRIC = "gateway_upstream_request_duration_seconds";
+    static final String INFLIGHT_REQUESTS_METRIC = "gateway_requests_in_flight";
+    static final String INFLIGHT_UPSTREAM_METRIC = "gateway_upstream_requests_in_flight";
 
     /**
      * Methods we expect to see; anything outside this set is collapsed to
@@ -75,6 +80,9 @@ public final class GatewayMetrics implements AutoCloseable {
     private final ConcurrentHashMap<RequestKey, Counter> requestCounters = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<TimerKey, Timer> requestTimers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UpstreamKey, Counter> upstreamCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UpstreamTimerKey, Timer> upstreamTimers = new ConcurrentHashMap<>();
+    private final AtomicInteger activeRequests = new AtomicInteger();
+    private final AtomicInteger activeUpstreamRequests = new AtomicInteger();
 
     /** URL → stable shard label (e.g. "shard-0"); replaced atomically on shard-config reload. */
     private volatile Map<String, String> shardLabels = Collections.emptyMap();
@@ -87,7 +95,7 @@ public final class GatewayMetrics implements AutoCloseable {
         registry.config().meterFilter(new MeterFilter() {
             @Override
             public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-                if (DURATION_METRIC.equals(id.getName())) {
+                if (DURATION_METRIC.equals(id.getName()) || UPSTREAM_DURATION_METRIC.equals(id.getName())) {
                     return DistributionStatisticConfig.builder()
                         .percentilesHistogram(true)
                         .build()
@@ -108,6 +116,13 @@ public final class GatewayMetrics implements AutoCloseable {
         new ProcessorMetrics().bindTo(registry);
         new UptimeMetrics().bindTo(registry);
         new FileDescriptorMetrics().bindTo(registry);
+
+        Gauge.builder(INFLIGHT_REQUESTS_METRIC, activeRequests, AtomicInteger::get)
+            .description("HTTP requests currently being handled by the gateway")
+            .register(registry);
+        Gauge.builder(INFLIGHT_UPSTREAM_METRIC, activeUpstreamRequests, AtomicInteger::get)
+            .description("Requests currently waiting on an upstream aggregator shard")
+            .register(registry);
     }
 
     @Override
@@ -150,6 +165,30 @@ public final class GatewayMetrics implements AutoCloseable {
         upstreamCounters.computeIfAbsent(key, this::newUpstreamCounter).increment();
     }
 
+    public void recordUpstreamDuration(String shardTarget, String jsonRpcMethod, boolean success, long durationNanos) {
+        String label = resolveShardLabel(shardTarget);
+        String method = normalizeMethod(jsonRpcMethod);
+        UpstreamTimerKey key = new UpstreamTimerKey(label, success, method);
+        upstreamTimers.computeIfAbsent(key, this::newUpstreamTimer)
+            .record(durationNanos, java.util.concurrent.TimeUnit.NANOSECONDS);
+    }
+
+    public void incrementActiveRequests() {
+        activeRequests.incrementAndGet();
+    }
+
+    public void decrementActiveRequests() {
+        activeRequests.updateAndGet(v -> v > 0 ? v - 1 : 0);
+    }
+
+    public void incrementActiveUpstreamRequests() {
+        activeUpstreamRequests.incrementAndGet();
+    }
+
+    public void decrementActiveUpstreamRequests() {
+        activeUpstreamRequests.updateAndGet(v -> v > 0 ? v - 1 : 0);
+    }
+
     public <T> void registerRateLimitBucketGauge(T source, ToDoubleFunction<T> sizeFn) {
         io.micrometer.core.instrument.Gauge.builder("gateway_ratelimit_buckets", source, sizeFn)
             .description("Per-API-key rate-limit buckets currently held in memory. " +
@@ -180,6 +219,15 @@ public final class GatewayMetrics implements AutoCloseable {
             .description("Requests forwarded to upstream aggregator shards")
             .tag("shard", k.shardLabel)
             .tag("outcome", k.success ? "success" : "error")
+            .register(registry);
+    }
+
+    private Timer newUpstreamTimer(UpstreamTimerKey k) {
+        return Timer.builder(UPSTREAM_DURATION_METRIC)
+            .description("Latency waiting for an upstream aggregator shard response")
+            .tag("shard", k.shardLabel)
+            .tag("outcome", k.success ? "success" : "error")
+            .tag("jsonrpc_method", k.method)
             .register(registry);
     }
 
@@ -214,4 +262,5 @@ public final class GatewayMetrics implements AutoCloseable {
     private record RequestKey(Outcome outcome, String method, String statusClass) {}
     private record TimerKey(Outcome outcome, String method) {}
     private record UpstreamKey(String shardLabel, boolean success) {}
+    private record UpstreamTimerKey(String shardLabel, boolean success, String method) {}
 }

--- a/src/test/java/org/unicitylabs/proxy/UpstreamH2cIntegrationTest.java
+++ b/src/test/java/org/unicitylabs/proxy/UpstreamH2cIntegrationTest.java
@@ -1,0 +1,83 @@
+package org.unicitylabs.proxy;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static java.net.http.HttpRequest.BodyPublishers.ofString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
+
+class UpstreamH2cIntegrationTest extends AbstractIntegrationTest {
+
+    @Override
+    protected void setUpConfigForTests(ProxyConfig config) {
+        try {
+            mockServer.stop();
+            mockServer = createH2cOnlyMockServer();
+            mockServer.start();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to start h2c mock server", e);
+        }
+
+        int mockServerPort = ((ServerConnector) mockServer.getConnectors()[0]).getLocalPort();
+        config.setPort(0);
+        config.setUpstreamH2cEnabled(true);
+        config.setUpstreamH2cMaxConnectionsPerDestination(2);
+        config.setUpstreamH2cMaxQueuedRequestsPerDestination(100);
+        setUpSingleShardAggregatorUrl("http://localhost:" + mockServerPort);
+
+        String testTokenTypesUrl = getClass().getResource("/test-token-types.json").toString();
+        config.setTokenTypeIdsUrl(testTokenTypesUrl);
+    }
+
+    @Test
+    void proxiesRequestsToH2cUpstream() throws Exception {
+        HttpRequest request = getNotAuthorizedRequestBuilder("/api/data")
+            .header(HttpHeader.CONTENT_TYPE.asString(), "application/json")
+            .POST(ofString("{\"name\":\"h2c\"}"))
+            .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(CREATED_201);
+        assertThat(response.headers().firstValue("X-H2C-Upstream")).hasValue("true");
+        assertThat(response.body()).contains("\"method\":\"POST\"");
+    }
+
+    private Server createH2cOnlyMockServer() {
+        Server server = new Server();
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        ServerConnector connector = new ServerConnector(server, new HTTP2CServerConnectionFactory(httpConfig));
+        connector.setPort(0);
+        server.addConnector(connector);
+        server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception {
+                ByteBuffer bodyBuffer = Content.Source.asByteBuffer(request);
+                int bodyLength = bodyBuffer.remaining();
+
+                response.setStatus(CREATED_201);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
+                response.getHeaders().put("X-H2C-Upstream", "true");
+                String body = "{\"method\":\"" + request.getMethod() + "\",\"received\":" + bodyLength + "}";
+                response.write(true, ByteBuffer.wrap(body.getBytes(StandardCharsets.UTF_8)), callback);
+                return true;
+            }
+        });
+        return server;
+    }
+}


### PR DESCRIPTION
Adds cleartext HTTP/2 support for gateway traffic:

  - Enables optional inbound h2c while keeping HTTP/1 clients supported.
  - Adds Jetty-based upstream h2c proxying for http:// shard targets.
  - Makes upstream h2c connection/window limits configurable.
  - Adds gateway/upstream latency and in-flight metrics.
  - Tunes compose defaults for gateway worker threads and file descriptor limits.
  - Documents h2c/HAProxy behavior.
  - Adds an integration test that proxies through an h2c-only upstream.